### PR TITLE
Fixed print when with options both `--nogroup` and `-l`

### DIFF
--- a/search/print/print.go
+++ b/search/print/print.go
@@ -37,9 +37,14 @@ func (self *Printer) Print() {
 			continue
 		}
 
+		if self.Option.FilesWithMatches {
+			self.printPath(arg.Path)
+			fmt.Println()
+			continue
+		}
 		if !self.Option.NoGroup {
 			self.printPath(arg.Path)
-			fmt.Printf("\n")
+			fmt.Println()
 		}
 		for _, v := range arg.Matches {
 			if v == nil {
@@ -48,14 +53,12 @@ func (self *Printer) Print() {
 			if self.Option.NoGroup {
 				self.printPath(arg.Path)
 			}
-			if !self.Option.FilesWithMatches {
-				self.printLineNumber(v.LineNum)
-				self.printMatch(arg.Pattern, v.Match)
-				fmt.Printf("\n")
-			}
+			self.printLineNumber(v.LineNum)
+			self.printMatch(arg.Pattern, v.Match)
+			fmt.Println()
 		}
-		if !self.Option.NoGroup && !self.Option.FilesWithMatches {
-			fmt.Printf("\n")
+		if !self.Option.NoGroup {
+			fmt.Println()
 		}
 	}
 	self.Done <- true


### PR DESCRIPTION
`--nogroup` と `-l` が同時に指定された場合の出力がおかしいです。

```
$ pt --nogroup -l func the_platinum_searcher
```

expected:

```
main.go
search/file/file.go
search/file/file_test.go
search/find/find.go
search/find/find_test.go
search/grep/grep.go
search/grep/grep_test.go
search/ignore/ignore.go
search/ignore/ignore_test.go
search/option/option.go
search/option/option_test.go
search/search.go
search/print/print.go
```

actual:

```
main.gomain.gosearch/file/file.gosearch/file/file_test.gosearch/find/find.gosearch/find/find.gosearch/find/find.gosearch/find/find.gosearch/find/find.gosearch/find/find.gosearch/find/find.gosearch/find/find.gosearch/find/find.gosearch/find/find.gosearch/find/find_test.gosearch/find/find_test.gosearch/find/find_test.gosearch/find/find_test.gosearch/grep/grep.gosearch/grep/grep.gosearch/grep/grep.gosearch/grep/grep_test.gosearch/grep/grep_test.gosearch/ignore/ignore.gosearch/ignore/ignore_test.gosearch/option/option.gosearch/option/option_test.gosearch/option/option_test.gosearch/print/print.gosearch/print/print.gosearch/print/print.gosearch/print/print.gosearch/print/print.gosearch/print/print.gosearch/print/print.gosearch/search.gosearch/search.gosearch/search.gosearch/search.go
```

ファイル名が "マッチした行数分" "改行されずに" 出力されています。
