### PR TITLE
Fix option parsing so that `--version` works.

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,14 +34,14 @@ func main() {
 		os.Exit(1)
 	}
 
-	if len(args) == 0 {
-		parser.WriteHelp(os.Stdout)
-		os.Exit(1)
-	}
-
 	if opts.Version {
 		fmt.Printf("%s\n", version)
 		os.Exit(0)
+	}
+
+	if len(args) == 0 {
+		parser.WriteHelp(os.Stdout)
+		os.Exit(1)
 	}
 
 	var root = "."


### PR DESCRIPTION
I noticed that the version wasn't being output if called like `pt.exe --version`. It _did_ work if I called it with an argument, though - like `pt.exe --version arg`. I just re-ordered the args length check and the `opts.Version` check.
