### PR TITLE
Add grep enconding option to Editor Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ if executable('pt')
   let g:unite_source_grep_command = 'pt'
   let g:unite_source_grep_default_opts = '--nogroup --nocolor'
   let g:unite_source_grep_recursive_opt = ''
+  let g:unite_source_grep_encoding = 'utf-8'
 endif
 ```
 


### PR DESCRIPTION
Windowsの場合、ptは外部コマンド呼び出しではutf-8で出力されるのですが、vimのデフォルトencodingはutf-8ではないので文字化けを防ぐために文字コードを明示しました。
