### PR TITLE
Make ignore patterns faster + a few other fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/monochromegane/terminal"
 	"github.com/monochromegane/the_platinum_searcher/search"
 	"github.com/monochromegane/the_platinum_searcher/search/option"
+	"github.com/monochromegane/the_platinum_searcher/search/grep"
 	"os"
 	"runtime"
 	"strings"
@@ -98,6 +99,7 @@ func main() {
 	}
 	if opts.Stats {
 		elapsed := time.Since(start)
+		fmt.Printf("%d Files Searched\n", grep.FilesSearched)
 		fmt.Printf("%s Elapsed\n", elapsed)
 	}
 }

--- a/search/grep/grep.go
+++ b/search/grep/grep.go
@@ -11,7 +11,6 @@ import (
 	"github.com/monochromegane/the_platinum_searcher/search/print"
 	"os"
 	"sync"
-	"fmt"
 )
 
 type Params struct {
@@ -25,15 +24,15 @@ type Grepper struct {
 	Option *option.Option
 }
 
+var FilesSearched uint
 func (self *Grepper) ConcurrentGrep() {
 	var wg sync.WaitGroup
-	var filesSearched uint
-	filesSearched = 0
+	FilesSearched = 0
 	sem := make(chan bool, self.Option.Proc)
 	for arg := range self.In {
 		sem <- true
 		wg.Add(1)
-		filesSearched++
+		FilesSearched++
 		go func(self *Grepper, arg *Params, sem chan bool) {
 			defer wg.Done()
 			self.Grep(arg.Path, arg.Encode, arg.Pattern, sem)
@@ -41,9 +40,6 @@ func (self *Grepper) ConcurrentGrep() {
 	}
 	wg.Wait()
 	close(self.Out)
-	if self.Option.Stats {
-		fmt.Printf("%d Files Searched\n", filesSearched)
-	}
 }
 
 func getDecoder(encode string) transform.Transformer {


### PR DESCRIPTION
Found below issues in ignore patterns logic which are fixed with this pull request:
- Whether to parse a directory or not should be searched before loading ignore patterns from a file within this. Otherwise we will miss this directory itself even though the ignore file within it applies only to subdirs
- Directory ignores should be searched against patterns with "/" in the end.
- The current method of globbing the files matching ignore patterns within this dir, and then matching against them and ignoring is very slow. using filepath.Match with pattern directly makes this much much faster. (In my tests on around 10000 files with around 10 ignore patterns, difference was more than a second before and after this fix)

Apart from this, also fixed the files searched thing getting printed out of order sometime as the queue of print() routines wasn't completely done. Now printing of all stats should happen properly.
