### PR TITLE
Add git's global gitignore setting

### DIFF
--- a/search/option/option.go
+++ b/search/option/option.go
@@ -1,29 +1,30 @@
 package option
 
 type Option struct {
-	Color            func()   `long:"color" description:"Print color codes in results (Enabled by default)"`
-	NoColor          func()   `long:"nocolor" description:"Don't print color codes in results (Disabled by default)"`
-	EnableColor      bool     // Enable color. Not user option.
-	NoGroup          bool     `long:"nogroup" description:"Don't print file name at header (Disabled by default)"`
-	FilesWithMatches bool     `short:"l" long:"files-with-matches" description:"Only print filenames that contain matches"`
-	VcsIgnore        []string `long:"vcs-ignore" description:"VCS ignore files (Default: .gitignore, .hgignore, .ptignore)"`
-	NoPtIgnore       bool     `long:"noptignore" description:"Don't use default ($Home/.ptignore) file for ignore patterns"`
-	Ignore           []string `long:"ignore" description:"Ignore files/directories matching pattern"`
-	IgnoreCase       bool     `short:"i" long:"ignore-case" description:"Match case insensitively"`
-	SmartCase        bool     `short:"S" long:"smart-case" description:"Match case insensitively unless PATTERN contains uppercase characters"`
-	FilesWithRegexp  string   `short:"g" description:"Print filenames matching PATTERN"`
-	FileSearchRegexp string   `short:"G" long:"file-search-regexp" description:"PATTERN Limit search to filenames matching PATTERN"`
-	Depth            int      `long:"depth" default:"25" default-mask:"-" description:"Search up to NUM directories deep (Default: 25)"`
-	Follow           bool     `short:"f" long:"follow" description:"Follow symlinks"`
-	After            int      `short:"A" long:"after" description:"Print lines after match"`
-	Before           int      `short:"B" long:"before" description:"Print lines before match"`
-	Context          int      `short:"C" long:"context" description:"Print lines before and after match"`
-	OutputEncode     string   `short:"o" long:"output-encode" description:"Specify output encoding (none, jis, sjis, euc)"`
-	SearchStream     bool     // Input from pipe. Not user option.
-	Regexp           bool     `short:"e" description:"Parse PATTERN as a regular expression (Disabled by default)"`
-	Proc             int      // Number of goroutine. Not user option.
-	Stats            bool     `long:"stats" description:"Print stats about files scanned, time taken, etc"`
-	Version          bool     `long:"version" description:"Show version"`
+	Color             func()   `long:"color" description:"Print color codes in results (Enabled by default)"`
+	NoColor           func()   `long:"nocolor" description:"Don't print color codes in results (Disabled by default)"`
+	EnableColor       bool     // Enable color. Not user option.
+	NoGroup           bool     `long:"nogroup" description:"Don't print file name at header (Disabled by default)"`
+	FilesWithMatches  bool     `short:"l" long:"files-with-matches" description:"Only print filenames that contain matches"`
+	VcsIgnore         []string `long:"vcs-ignore" description:"VCS ignore files (Default: .gitignore, .hgignore, .ptignore)"`
+	NoPtIgnore        bool     `long:"noptignore" description:"Don't use default ($Home/.ptignore) file for ignore patterns"`
+	NoGlobalGitIgnore bool     `long:"noglobal-gitignore" description:"Don't use git's global gitignore file for ignore patterns"`
+	Ignore            []string `long:"ignore" description:"Ignore files/directories matching pattern"`
+	IgnoreCase        bool     `short:"i" long:"ignore-case" description:"Match case insensitively"`
+	SmartCase         bool     `short:"S" long:"smart-case" description:"Match case insensitively unless PATTERN contains uppercase characters"`
+	FilesWithRegexp   string   `short:"g" description:"Print filenames matching PATTERN"`
+	FileSearchRegexp  string   `short:"G" long:"file-search-regexp" description:"PATTERN Limit search to filenames matching PATTERN"`
+	Depth             int      `long:"depth" default:"25" default-mask:"-" description:"Search up to NUM directories deep (Default: 25)"`
+	Follow            bool     `short:"f" long:"follow" description:"Follow symlinks"`
+	After             int      `short:"A" long:"after" description:"Print lines after match"`
+	Before            int      `short:"B" long:"before" description:"Print lines before match"`
+	Context           int      `short:"C" long:"context" description:"Print lines before and after match"`
+	OutputEncode      string   `short:"o" long:"output-encode" description:"Specify output encoding (none, jis, sjis, euc)"`
+	SearchStream      bool     // Input from pipe. Not user option.
+	Regexp            bool     `short:"e" description:"Parse PATTERN as a regular expression (Disabled by default)"`
+	Proc              int      // Number of goroutine. Not user option.
+	Stats             bool     `long:"stats" description:"Print stats about files scanned, time taken, etc"`
+	Version           bool     `long:"version" description:"Show version"`
 }
 
 func (self *Option) VcsIgnores() []string {


### PR DESCRIPTION
Issue solved: When using `pt`, I expect it to match `ag` behavior.  I tried out `pt` and noticed that it does not respect git's global gitignore setting. The behavior in `ag` is that it executes `git config -z --get core.excludesfile` and if there's a global gitignore file, it will use those ignored files as part of it's ignored file list.

Solution: Execute git command to check if there's a global gitignore setting.  If so, use that as a filter for ignoring files.

Credit for idea and git commands: https://github.com/ggreer/the_silver_searcher/pull/175.

Design questions/items needing revision:
- I'm relatively new to golang, if there are stylistic changes to better fit this project please let me know.
- I placed the behavior for global gitignore in the same file where `#addHomePtIgnore` is located. Is there a better location?
- I'm uncertain how to test this behavior, but if you like the patch I'll either research it further or take your advice on testing.
- It's currently tied into the same conditional in `find.go` where we check for `self.Option.NoPtIgnore == false`. Should the global ignore have it's own option rather than being tied into `NoPtIgnore`?

Thank you for building this tool!  I expect this patch will need revision before being included.

Hopefully this PR can start that conversation.
