### PR TITLE
README: the_platinum_searcher is now in Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,7 @@ Download from following urls.
 Or, you can use Homebrew (Only MacOSX).
 
 ```sh
-$ brew tap monochromegane/pt
-$ brew install pt
+$ brew install the_platinum_searcher
 ```
 
 ## Usage


### PR DESCRIPTION
`the_platinum_searcher` has now been added to the main Homebrew repository.

For more info, refer to the commit: https://github.com/Homebrew/homebrew/commit/0641864c6f4f2495344ed0ab1762085badc79dc6
