### PR TITLE
Update to correct Homebrew formula name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Download from the following url.
 Or, you can use Homebrew (Only MacOSX).
 
 ```sh
-$ brew install pt
+$ brew install the_platinum_searcher
 ```
 
 ## Usage


### PR DESCRIPTION
The current readme lists the formula name as `pt` when it's actually `the_platinum_searcher`<sup>[1](https://github.com/Homebrew/homebrew/blob/master/Library/Formula/the_platinum_searcher.rb)</sup>.

1 - https://github.com/Homebrew/homebrew/blob/master/Library/Formula/the_platinum_searcher.rb
