### PR TITLE
Add --tree option

### DIFF
--- a/option.go
+++ b/option.go
@@ -27,6 +27,7 @@ type Option struct {
 	Proc              int      // Number of goroutine. Not user option.
 	Stats             bool     `long:"stats" description:"Print stats about files scanned, time taken, etc"`
 	Version           bool     `long:"version" description:"Show version"`
+	Tree              bool     `long:"tree" description:"Print tree"`
 }
 
 func (o *Option) VcsIgnores() []string {

--- a/print.go
+++ b/print.go
@@ -8,6 +8,7 @@ import (
 
 	"code.google.com/p/go.text/encoding/japanese"
 	"code.google.com/p/go.text/transform"
+	"github.com/homburg/tree"
 	"github.com/shiena/ansicolor"
 )
 
@@ -46,6 +47,9 @@ func Print(in chan *PrintParams, done chan bool, option *Option) {
 func (p *print) Start() {
 	FileMatchCount = 0
 	MatchCount = 0
+
+	var files []string
+
 	for arg := range p.In {
 
 		if p.Option.FilesWithRegexp != "" {
@@ -56,6 +60,11 @@ func (p *print) Start() {
 		}
 
 		if len(arg.Matches) == 0 {
+			continue
+		}
+
+		if p.Option.Tree {
+			files = append(files, arg.Path)
 			continue
 		}
 
@@ -95,6 +104,13 @@ func (p *print) Start() {
 			fmt.Println()
 		}
 	}
+
+	if p.Option.Tree {
+		t := tree.New("/")
+		t.EatLines(files)
+		fmt.Fprint(p.writer, t.Format())
+	}
+
 	if p.Option.Stats {
 		fmt.Printf("%d Files Matched\n", FileMatchCount)
 		fmt.Printf("%d Total Text Matches\n", MatchCount)


### PR DESCRIPTION
'cause it's pretty

Example:

``` bash
$ pt g files --tree
.
└── files
    ├── ascii.txt
    ├── depth
    │   ├── dir_1
    │   │   ├── dir_2
    │   │   │   └── file_3.txt
    │   │   └── file_2.txt
    │   └── file_1.txt
    ├── ja
    │   ├── broken_euc-jp.txt
    │   ├── broken_shift_jis.txt
    │   ├── broken_utf8.txt
    │   ├── euc-jp.txt
    │   ├── shift_jis.txt
    │   └── utf8.txt
    └── vcs
        ├── absolute
        │   └── ignore.txt
        ├── ignore
        │   └── ignore.txt
        └── match
            ├── ignore.txt
            └── match.txt
```
