### PR TITLE
Search in all specified PATHs

### DIFF
--- a/cmd/pt/main.go
+++ b/cmd/pt/main.go
@@ -57,13 +57,19 @@ func main() {
 		}
 	}
 
-	var root = "."
-	if len(args) == 2 {
-		root = strings.TrimRight(args[1], "\"")
-		_, err := os.Lstat(root)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", err)
-			os.Exit(1)
+	var roots = []string{"."}
+	if len(args) >= 2 {
+		roots = []string{}
+		// check if every argument exists on the filesystem
+		for _, root := range args[1:] {
+			path := strings.TrimRight(root, "\"")
+			_, err := os.Lstat(path)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s\n", err)
+				os.Exit(1)
+			} else {
+				roots = append(roots, path)
+			}
 		}
 	}
 
@@ -93,7 +99,7 @@ func main() {
 
 	start := time.Now()
 
-	searcher := pt.PlatinumSearcher{root, pattern, &opts}
+	searcher := pt.PlatinumSearcher{roots, pattern, &opts}
 	err = searcher.Search()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)

--- a/find.go
+++ b/find.go
@@ -13,12 +13,15 @@ type find struct {
 	Option *Option
 }
 
-func Find(root string, pattern *Pattern, out chan *GrepParams, option *Option) {
+func Find(roots []string, pattern *Pattern, out chan *GrepParams, option *Option) {
 	find := find{
 		Out:    out,
 		Option: option,
 	}
-	find.Start(root, pattern)
+	for _, root := range roots {
+		find.Start(root, pattern)
+	}
+	close(find.Out)
 }
 
 func (f *find) Start(root string, pattern *Pattern) {
@@ -32,7 +35,6 @@ func (f *find) Start(root string, pattern *Pattern) {
 func (f *find) findStream(pattern *Pattern) {
 	// TODO: File type is fixed in ASCII because it can not determine the character code.
 	f.Out <- &GrepParams{"", ASCII, pattern}
-	close(f.Out)
 }
 
 func (f *find) findFile(root string, pattern *Pattern) {
@@ -92,7 +94,6 @@ func (f *find) findFile(root string, pattern *Pattern) {
 		f.Out <- &GrepParams{path, fileType, pattern}
 		return nil, ignores
 	})
-	close(f.Out)
 }
 
 type WalkFunc func(path string, info *FileInfo, depth int, ignores ignoreMatchers, err error) (error, ignoreMatchers)

--- a/search.go
+++ b/search.go
@@ -1,8 +1,9 @@
 package the_platinum_searcher
 
 type PlatinumSearcher struct {
-	Root, Pattern string
-	Option        *Option
+	Roots   []string
+	Pattern string
+	Option  *Option
 }
 
 func (p *PlatinumSearcher) Search() error {
@@ -35,7 +36,7 @@ func (p *PlatinumSearcher) pattern() (*Pattern, error) {
 }
 
 func (p *PlatinumSearcher) find(out chan *GrepParams, pattern *Pattern) {
-	Find(p.Root, pattern, out, p.Option)
+	Find(p.Roots, pattern, out, p.Option)
 }
 
 func (p *PlatinumSearcher) grep(in chan *GrepParams, out chan *PrintParams) {


### PR DESCRIPTION
This pull request makes Searcher scan all the PATHs that are given in the command line, not just the first one as before. Fixes issue #68.
