### PR TITLE
Improve checking stdin type

### DIFF
--- a/cmd/pt/main.go
+++ b/cmd/pt/main.go
@@ -51,7 +51,13 @@ func main() {
 
 	opts.SearchStream = false
 	if len(args) == 1 {
-		if !terminal.IsTerminal(os.Stdin) {
+		fi, err := os.Stdin.Stat()
+		if err != nil {
+			os.Exit(1)
+		}
+
+		mode := fi.Mode()
+		if (mode & os.ModeNamedPipe != 0) || mode.IsRegular() {
 			opts.SearchStream = true
 			opts.NoGroup = true
 		}


### PR DESCRIPTION
This checking is same as **ag**.
Code is [here](https://github.com/ggreer/the_silver_searcher/blob/f1b860e629b70463e38a8ff69c9afe46c918e54f/src/options.c#L309)

Command execution functions(`call-process`, `process-file` etc) of Emacs uses `/dev/null` as stdin,
`terminal.IsTerminal` returns false and `SearchStream` flag is enabled for such cases.
So we can't use **pt** from such functions(`pt.el` uses special function).
