### PR TITLE
Don't returns exit status 1 if there are matches

### DIFF
--- a/cmd/pt/main.go
+++ b/cmd/pt/main.go
@@ -109,7 +109,7 @@ func main() {
 		fmt.Printf("%s Elapsed\n", elapsed)
 	}
 
-	if pt.FileMatchCount == 0 {
+	if pt.FileMatchCount == 0 && pt.MatchCount == 0 {
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Original code, pt returns exit status 1 if there are matches

```
% pt --nogroup os
main.go:5:	"os"
main.go:39:		os.Exit(1)
main.go:44:		os.Exit(0)
main.go:48:		parser.WriteHelp(os.Stdout)
main.go:49:		os.Exit(1)
main.go:54:		if !terminal.IsTerminal(os.Stdin) {
main.go:65:			_, err := os.Lstat(root)
main.go:67:				fmt.Fprintf(os.Stderr, "%s\n", err)
main.go:68:				os.Exit(1)
main.go:76:	if !terminal.IsTerminal(os.Stdout) {
main.go:103:		fmt.Fprintf(os.Stderr, "%s\n", err)
main.go:104:		os.Exit(1)
main.go:113:		os.Exit(1)
% echo $?
1
```

This behavior is different from `grep` or `ag`.