### PR TITLE
Fixed find panics on invalid root path.

### DIFF
--- a/find.go
+++ b/find.go
@@ -63,6 +63,9 @@ func (f *find) findFile(root string, pattern *Pattern, done chan struct{}) {
 
 	ignores = append(ignores, genericIgnore(f.Option.Ignore))
 	Walk(root, ignores, f.Option.Follow, func(path string, info *FileInfo, depth int, ignores ignoreMatchers, err error) (error, ignoreMatchers) {
+		if err != nil {
+			return err, ignores
+		}
 		if info.IsDir() {
 			if depth > f.Option.Depth+1 {
 				return filepath.SkipDir, ignores

--- a/find_test.go
+++ b/find_test.go
@@ -136,3 +136,14 @@ func TestFindWithStream(t *testing.T) {
 		}
 	}
 }
+
+func TestFindWithInvalidRoot(t *testing.T) {
+	out := make(chan *GrepParams)
+	find := find{out, defaultOpts()}
+	go find.Start([]string{"invalidpath"}, &Pattern{Pattern: "go"})
+
+	for o := range out {
+		t.Errorf("It should not return any file, but returned: %s", o.Path)
+		return
+	}
+}


### PR DESCRIPTION
Currently, if a non-existent root path is provided to `find.Start` it panics. This is an attempt to fix that.