### PR TITLE
fix 'pt -i "foo("'

### DIFF
--- a/files/ascii.txt
+++ b/files/ascii.txt
@@ -1,2 +1,3 @@
 ascii.txt
 go test
+a rumba( is here

--- a/find_test.go
+++ b/find_test.go
@@ -115,7 +115,10 @@ func TestFindWithDepth(t *testing.T) {
 func TestFindWithFileSearchPattern(t *testing.T) {
 	out := make(chan *GrepParams)
 	find := find{out, &Option{}}
-	pattern, _ := NewPattern("go", "match.txt", true, true, false)
+	pattern, err := NewPattern("go", "match.txt", true, true, false)
+	if err != nil {
+		t.Errorf("NewPattern() failed with %s\n", err)
+	}
 	go find.Start([]string{"files/vcs/match"}, pattern)
 
 	for o := range out {
@@ -134,5 +137,25 @@ func TestFindWithStream(t *testing.T) {
 		if o.Path != "" {
 			t.Errorf("It should not contains file. %s", o.Path)
 		}
+	}
+}
+
+func TestFindNonRegex(t *testing.T) {
+	out := make(chan *GrepParams)
+	find := find{out, &Option{}}
+	pattern, err := NewPattern("Rumba(", "ascii.txt", false, true, false)
+	if err != nil {
+		t.Errorf("NewPattern() failed with %s\n", err)
+	}
+	go find.Start([]string{"files"}, pattern)
+	var res []*GrepParams
+	for o := range out {
+		res = append(res, o)
+	}
+	if len(res) != 1 {
+		t.Errorf("expected 1 result, got %d\n", len(res))
+	}
+	if res[0].Path != "files/ascii.txt" {
+		t.Errorf("expected to find in 'files/ascii.txt', found in '%s'\n", res[0].Path)
 	}
 }

--- a/pattern.go
+++ b/pattern.go
@@ -24,10 +24,15 @@ func NewPattern(pattern, filePattern string, smartCase, ignoreCase, useRegexp bo
 
 	var regPattern *regexp.Regexp
 	var patternErr error
-	if ignoreCase {
-		regPattern, patternErr = regexp.Compile(`(?i)(` + pattern + `)`)
-	} else if useRegexp {
-		regPattern, patternErr = regexp.Compile(`(` + pattern + `)`)
+	if useRegexp {
+		if ignoreCase {
+			regPattern, patternErr = regexp.Compile(`(?i)(` + pattern + `)`)
+		} else {
+			regPattern, patternErr = regexp.Compile(`(` + pattern + `)`)
+		}
+	} else if ignoreCase {
+		// not used during matching but used to simplify highlighting in decorator.go
+		regPattern, patternErr = regexp.Compile(`(?i)(` + regexp.QuoteMeta(pattern) + `)`)
 	}
 
 	var regFile *regexp.Regexp


### PR DESCRIPTION
i.e. non-regexp, case-insenstitive search where term would be an invalid regexp

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/monochromegane/the_platinum_searcher/81)
<!-- Reviewable:end -->
