### PR TITLE
Fix STDIN check for Windows

### DIFF
--- a/cmd/pt/main.go
+++ b/cmd/pt/main.go
@@ -52,14 +52,21 @@ func main() {
 	opts.SearchStream = false
 	if len(args) == 1 {
 		fi, err := os.Stdin.Stat()
-		if err != nil {
-			os.Exit(1)
-		}
+		if runtime.GOOS == "windows" {
+			if err == nil {
+				opts.SearchStream = true
+				opts.NoGroup = true
+			}
+		} else {
+			if err != nil {
+				os.Exit(1)
+			}
 
-		mode := fi.Mode()
-		if (mode & os.ModeNamedPipe != 0) || mode.IsRegular() {
-			opts.SearchStream = true
-			opts.NoGroup = true
+			mode := fi.Mode()
+			if (mode & os.ModeNamedPipe != 0) || mode.IsRegular() {
+				opts.SearchStream = true
+				opts.NoGroup = true
+			}
 		}
 	}
 


### PR DESCRIPTION
Sorry #71 is not enough for Windows platform.

On Windows, os.Stdin.Stat returns error if STDIN is a tty or Nul. While it does not return
error if STDIN is a pipe or redirected file.

See Also
- https://github.com/cmfatih/yapi/blob/9a9788c6938710a1ca066b34ac4649368c651e12/stdin/stdin.go#L70