### PR TITLE
Add --pattern option

### DIFF
--- a/cmd/pt/main.go
+++ b/cmd/pt/main.go
@@ -44,7 +44,21 @@ func main() {
 		os.Exit(0)
 	}
 
-	if len(args) == 0 && opts.FilesWithRegexp == "" {
+	pattern := ""
+	if opts.FilesWithRegexp == "" && len(args) > 0 {
+		pattern = args[0]
+	}
+
+	if opts.Pattern != "" {
+		pattern = opts.Pattern
+	}
+
+	if opts.WordRegexp {
+		opts.Regexp = true
+		pattern = "\\b" + pattern + "\\b"
+	}
+
+	if pattern == "" && opts.FilesWithRegexp == "" {
 		parser.WriteHelp(os.Stdout)
 		os.Exit(1)
 	}
@@ -101,16 +115,6 @@ func main() {
 	if opts.Context > 0 {
 		opts.Before = opts.Context
 		opts.After = opts.Context
-	}
-
-	pattern := ""
-	if opts.FilesWithRegexp == "" && len(args) > 0 {
-		pattern = args[0]
-	}
-
-	if opts.WordRegexp {
-		opts.Regexp = true
-		pattern = "\\b" + pattern + "\\b"
 	}
 
 	start := time.Now()

--- a/option.go
+++ b/option.go
@@ -32,6 +32,7 @@ type Option struct {
 	Stats             bool     `long:"stats" description:"Print stats about files scanned, time taken, etc"`
 	Parallel          bool     `long:"parallel" description:"Use as many concurrent finders as possible, this will lead the result disorder"`
 	Version           bool     `long:"version" description:"Show version"`
+	Pattern           string   `long:"pattern" description:"Pattern to search for"`
 }
 
 func (o *Option) VcsIgnores() []string {


### PR DESCRIPTION
I need `--pattern=PATTERN` option to search words start with hyphen.

```
$ pt --pattern=-10
```

Or is there any way to do it?

## Considerations

* Priority order of `PATTERN` argument and `--pattern` option
* Position of `--pattern` in usage