### PR TITLE
Prevents duplicate help messages being printed out, when using ./pt -h

### DIFF
--- a/platinum_searcher.go
+++ b/platinum_searcher.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"github.com/monochromegane/conflag"
 	"github.com/monochromegane/go-home"
@@ -39,7 +40,9 @@ func (p PlatinumSearcher) Run(args []string) int {
 
 	args, err := parser.ParseArgs(args)
 	if err != nil {
-		fmt.Fprintf(p.Err, "%s\n", err)
+		if !strings.Contains(err.Error(), "Usage:") {
+			fmt.Fprintf(p.Err, "%s\n", err)
+		}
 		return ExitCodeError
 	}
 


### PR DESCRIPTION
The err message itself contains the entirety of the help message, plus
the flags library has already output, so when catching and displaying
the error, it duplicates the help message.

The check simply looks for 'Usage:' which is an indicator that it is a
help message and not an actual error.