### PR TITLE
Don't print go-flags error message

### DIFF
--- a/platinum_searcher.go
+++ b/platinum_searcher.go
@@ -39,7 +39,6 @@ func (p PlatinumSearcher) Run(args []string) int {
 
 	args, err := parser.ParseArgs(args)
 	if err != nil {
-		fmt.Fprintf(p.Err, "%s\n", err)
 		return ExitCodeError
 	}
 


### PR DESCRIPTION
Error messages are printed in go-flags package, because PrintErrors
flag is set(It is contained in flags.Default).

This is related to #115.