### PR TITLE
Fix --follow option issue

### DIFF
--- a/find.go
+++ b/find.go
@@ -63,8 +63,9 @@ func (f find) findFile(root string, regexp *regexp.Regexp) {
 		}
 	}
 
-	concurrentWalk(root, ignores, func(path string, info fileInfo, depth int, ignores ignoreMatchers) (ignoreMatchers, error) {
-		if info.isDir(f.opts.SearchOption.Follow) {
+	followed := f.opts.SearchOption.Follow
+	concurrentWalk(root, ignores, followed, func(path string, info fileInfo, depth int, ignores ignoreMatchers) (ignoreMatchers, error) {
+		if info.isDir(followed) {
 			if depth > f.opts.SearchOption.Depth+1 {
 				return ignores, filepath.SkipDir
 			}

--- a/walk.go
+++ b/walk.go
@@ -9,16 +9,16 @@ import (
 
 type walkFunc func(path string, info fileInfo, depth int, ignores ignoreMatchers) (ignoreMatchers, error)
 
-func concurrentWalk(root string, ignores ignoreMatchers, walkFn walkFunc) error {
+func concurrentWalk(root string, ignores ignoreMatchers, followed bool, walkFn walkFunc) error {
 	info, err := os.Lstat(root)
 	if err != nil {
 		return err
 	}
 	sem := make(chan struct{}, 16)
-	return walk(root, newFileInfo(root, info), 1, ignores, walkFn, sem)
+	return walk(root, newFileInfo(root, info), 1, ignores, followed, walkFn, sem)
 }
 
-func walk(path string, info fileInfo, depth int, parentIgnores ignoreMatchers, walkFn walkFunc, sem chan struct{}) error {
+func walk(path string, info fileInfo, depth int, parentIgnores ignoreMatchers, followed bool, walkFn walkFunc, sem chan struct{}) error {
 	ignores, walkError := walkFn(path, info, depth, parentIgnores)
 	if walkError != nil {
 		if info.IsDir() && walkError == filepath.SkipDir {
@@ -27,7 +27,7 @@ func walk(path string, info fileInfo, depth int, parentIgnores ignoreMatchers, w
 		return walkError
 	}
 
-	if !info.IsDir() {
+	if !info.isDir(followed) {
 		return nil
 	}
 
@@ -46,10 +46,10 @@ func walk(path string, info fileInfo, depth int, parentIgnores ignoreMatchers, w
 			go func(path string, file fileInfo, depth int, ignores ignoreMatchers, wg *sync.WaitGroup) {
 				defer wg.Done()
 				defer func() { <-sem }()
-				walk(path, file, depth, ignores, walkFn, sem)
+				walk(path, file, depth, ignores, followed, walkFn, sem)
 			}(filepath.Join(path, file.Name()), f, depth, ignores, wg)
 		default:
-			walk(filepath.Join(path, file.Name()), f, depth, ignores, walkFn, sem)
+			walk(filepath.Join(path, file.Name()), f, depth, ignores, followed, walkFn, sem)
 		}
 	}
 	wg.Wait()


### PR DESCRIPTION
- Pass follow option to walk function
- Use info.isDir instead of info.IsDir for checking symbolic linked directory

This is related to #122.
CC: @jpcirrus

