### PR TITLE
Disable after, before, context option when count option is specified

### DIFF
--- a/platinum_searcher.go
+++ b/platinum_searcher.go
@@ -65,6 +65,12 @@ func (p PlatinumSearcher) Run(args []string) int {
 		args = append([]string{""}, args...)
 	}
 
+	if opts.OutputOption.Count {
+		opts.OutputOption.Before = 0
+		opts.OutputOption.After = 0
+		opts.OutputOption.Context = 0
+	}
+
 	search := search{
 		roots: p.rootsFrom(args),
 		out:   p.Out,


### PR DESCRIPTION
This is related to #125.
CC: @vovcacik