### PR TITLE
Turn off SearchStream flag by explicit root path

### DIFF
--- a/platinum_searcher.go
+++ b/platinum_searcher.go
@@ -57,7 +57,7 @@ func (p PlatinumSearcher) Run(args []string) int {
 		opts.OutputOption.EnableGroup = false
 	}
 
-	if p.givenStdin() {
+	if p.givenStdin() && p.noRootPathIn(args) {
 		opts.SearchOption.SearchStream = true
 	}
 
@@ -111,4 +111,8 @@ func (p PlatinumSearcher) givenStdin() bool {
 		}
 	}
 	return false
+}
+
+func (p PlatinumSearcher) noRootPathIn(args []string) bool {
+	return len(args) == 1
 }


### PR DESCRIPTION
Pt which invoked from NTEmacs or Cygwin environment never
turns off SearchStream flag even though STDIN is not a pipe.

To workaround this issue, we should turn off SearchStream flag
if root path(s) are specified since they mean no need to read
contents from STDIN.
