### PR TITLE
Use bold blue color for path decoration

### DIFF
--- a/decorator.go
+++ b/decorator.go
@@ -9,7 +9,7 @@ import (
 const (
 	ColorReset      = "\x1b[0m\x1b[K"
 	ColorLineNumber = "\x1b[1;33m"  /* yellow with black background */
-	ColorPath       = "\x1b[1;32m"  /* bold green */
+	ColorPath       = "\x1b[1;34m"  /* bold blue */
 	ColorMatch      = "\x1b[30;43m" /* black with yellow background */
 
 	SeparatorColon  = ":"


### PR DESCRIPTION
File paths in result is too obscure with some colorschemes in iTerm2.  It is because the color “Bold Green”(color code 010) has a special use for those colorschemes.

This PR use “Bold Blue”(color code 012) for that. Here are samples, above is `master`, below is my forked version.

color | palette | sample
------------ | ------------- | -------------
iTerm2 (default) | <img width="322" alt="2016-01-24 13 58 28" src="https://cloud.githubusercontent.com/assets/1239245/12534566/9d3d09de-c2a2-11e5-80dd-82e340376f15.png"> | <img width="190" alt="2016-01-24 14 06 02" src="https://cloud.githubusercontent.com/assets/1239245/12534590/13708260-c2a4-11e5-9571-445982bef764.png">
[Solarized](http://ethanschoonover.com/solarized) | <img width="318" alt="2016-01-24 13 55 06" src="https://cloud.githubusercontent.com/assets/1239245/12534568/b1c10d38-c2a2-11e5-8335-fb89c2015cb6.png"> | <img width="188" alt="2016-01-24 14 06 18" src="https://cloud.githubusercontent.com/assets/1239245/12534602/a16b58c4-c2a4-11e5-9c7d-1f537ec57727.png">
[base16-default](http://chriskempson.github.io/base16/) | <img width="320" alt="2016-01-24 13 55 41" src="https://cloud.githubusercontent.com/assets/1239245/12534574/e8b4c000-c2a2-11e5-9965-e7c647edeb49.png"> | <img width="188" alt="2016-01-24 14 06 33" src="https://cloud.githubusercontent.com/assets/1239245/12534604/b39d1aaa-c2a4-11e5-9e3c-9c100fe1db61.png">
[Duotones Dark](http://atelierbram.github.io/syntax-highlighting/duotones/) | <img width="320" alt="2016-01-24 13 56 11" src="https://cloud.githubusercontent.com/assets/1239245/12534575/04074242-c2a3-11e5-9a97-86b96a1eab0e.png"> | <img width="187" alt="2016-01-24 14 06 56" src="https://cloud.githubusercontent.com/assets/1239245/12534605/bf9c451a-c2a4-11e5-938f-dd77524583f3.png">

I think it is better that the colors in `decorator.go` can be specified by `.ptconfig.toml`. But this patch is tentatively enough to this use.
