### PR TITLE
Color code options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The file is TOML format like the following.
 color = true
 context = 3
 ignore = ["dir1", "dir2"]
+color-path = "1;34"
 ```
 
 The options are same as command line options.

--- a/decorator.go
+++ b/decorator.go
@@ -56,7 +56,12 @@ func newColor(pattern pattern, option Option) color {
 }
 
 func ansiEscape(code string) string {
-	return "\x1b[" + code + "m"
+	re := regexp.MustCompile("[^0-9;]")
+	sanitized := re.ReplaceAllString(code, "")
+	if sanitized == "" {
+		sanitized = "0" // all attributes off
+	}
+	return "\x1b[" + sanitized + "m"
 }
 
 func (c color) path(path string) string {

--- a/decorator.go
+++ b/decorator.go
@@ -7,10 +7,7 @@ import (
 )
 
 const (
-	ColorReset      = "\x1b[0m\x1b[K"
-	ColorLineNumber = "\x1b[1;33m"  /* yellow with black background */
-	ColorPath       = "\x1b[1;32m"  /* bold green */
-	ColorMatch      = "\x1b[30;43m" /* black with yellow background */
+	ColorReset = "\x1b[0m\x1b[K"
 
 	SeparatorColon  = ":"
 	SeparatorHyphen = "-"
@@ -25,7 +22,7 @@ type decorator interface {
 
 func newDecorator(pattern pattern, option Option) decorator {
 	if option.OutputOption.EnableColor {
-		return newColor(pattern)
+		return newColor(pattern, option)
 	} else {
 		return plain{}
 	}
@@ -35,27 +32,39 @@ type color struct {
 	from   string
 	to     string
 	regexp *regexp.Regexp
+
+	colorLineNumber string
+	colorPath       string
+	colorMatch      string
 }
 
-func newColor(pattern pattern) color {
-	color := color{}
+func newColor(pattern pattern, option Option) color {
+	color := color{
+		colorLineNumber: ansiEscape(option.OutputOption.ColorCodeLineNumber),
+		colorPath:       ansiEscape(option.OutputOption.ColorCodePath),
+		colorMatch:      ansiEscape(option.OutputOption.ColorCodeMatch),
+	}
 	if pattern.regexp == nil {
 		p := string(pattern.pattern)
 		color.from = p
-		color.to = ColorMatch + p + ColorReset
+		color.to = color.colorMatch + p + ColorReset
 	} else {
-		color.to = ColorMatch + "${1}" + ColorReset
+		color.to = color.colorMatch + "${1}" + ColorReset
 		color.regexp = pattern.regexp
 	}
 	return color
 }
 
+func ansiEscape(code string) string {
+	return "\x1b[" + code + "m"
+}
+
 func (c color) path(path string) string {
-	return ColorPath + path + ColorReset
+	return c.colorPath + path + ColorReset
 }
 
 func (c color) lineNumber(lineNum int) string {
-	return ColorLineNumber + strconv.Itoa(lineNum) + ColorReset
+	return c.colorLineNumber + strconv.Itoa(lineNum) + ColorReset
 }
 
 func (c color) columnNumber(columnNum int) string {

--- a/option.go
+++ b/option.go
@@ -11,19 +11,25 @@ type Option struct {
 
 // Output options.
 type OutputOption struct {
-	Color            func() `long:"color" description:"Print color codes in results (default: true)"`
-	NoColor          func() `long:"nocolor" description:"Don't print color codes in results (default: false)"`
-	EnableColor      bool   // Enable color. Not user option.
-	Group            func() `long:"group" description:"Print file name at header (default: true)"`
-	NoGroup          func() `long:"nogroup" description:"Don't print file name at header (default: false)"`
-	EnableGroup      bool   // Enable group. Not user option.
-	Column           bool   `long:"column" description:"Print column (default: false)"`
-	After            int    `short:"A" long:"after" description:"Print lines after match"`
-	Before           int    `short:"B" long:"before" description:"Print lines before match"`
-	Context          int    `short:"C" long:"context" description:"Print lines before and after match"`
-	FilesWithMatches bool   `short:"l" long:"files-with-matches" description:"Only print filenames that contain matches"`
-	Count            bool   `short:"c" long:"count" description:"Only print the number of matching lines for each input file."`
-	OutputEncode     string `short:"o" long:"output-encode" description:"Specify output encoding (none, jis, sjis, euc)"`
+	Color               func()       `long:"color" description:"Print color codes in results (default: true)"`
+	NoColor             func()       `long:"nocolor" description:"Don't print color codes in results (default: false)"`
+	EnableColor         bool         // Enable color. Not user option.
+	ColorLineNumber     func(string) `long:"color-line-number" description:"Color codes for line numbers (default: 1;33)"`
+	ColorPath           func(string) `long:"color-path" description:"Color codes for path names (default: 1;32)"`
+	ColorMatch          func(string) `long:"color-match" description:"Color codes for result matches (default: 30;43)"`
+	ColorCodeLineNumber string       // Color line numbers. Not user option.
+	ColorCodePath       string       // Color path names. Not user option.
+	ColorCodeMatch      string       // Color result matches. Not user option.
+	Group               func()       `long:"group" description:"Print file name at header (default: true)"`
+	NoGroup             func()       `long:"nogroup" description:"Don't print file name at header (default: false)"`
+	EnableGroup         bool         // Enable group. Not user option.
+	Column              bool         `long:"column" description:"Print column (default: false)"`
+	After               int          `short:"A" long:"after" description:"Print lines after match"`
+	Before              int          `short:"B" long:"before" description:"Print lines before match"`
+	Context             int          `short:"C" long:"context" description:"Print lines before and after match"`
+	FilesWithMatches    bool         `short:"l" long:"files-with-matches" description:"Only print filenames that contain matches"`
+	Count               bool         `short:"c" long:"count" description:"Only print the number of matching lines for each input file."`
+	OutputEncode        string       `short:"o" long:"output-encode" description:"Specify output encoding (none, jis, sjis, euc)"`
 }
 
 func newOutputOption() *OutputOption {
@@ -36,6 +42,13 @@ func newOutputOption() *OutputOption {
 	opt.Group = opt.SetEnableGroup
 	opt.NoGroup = opt.SetDisableGroup
 	opt.EnableGroup = true
+
+	opt.ColorLineNumber = opt.SetColorLineNumber
+	opt.ColorPath = opt.SetColorPath
+	opt.ColorMatch = opt.SetColorMatch
+	opt.ColorCodeLineNumber = "1;33" // yellow with black background
+	opt.ColorCodePath = "1;32"       // bold green
+	opt.ColorCodeMatch = "30;43"     // black with yellow background
 
 	return opt
 }
@@ -54,6 +67,18 @@ func (o *OutputOption) SetEnableGroup() {
 
 func (o *OutputOption) SetDisableGroup() {
 	o.EnableGroup = false
+}
+
+func (o *OutputOption) SetColorLineNumber(code string) {
+	o.ColorCodeLineNumber = code
+}
+
+func (o *OutputOption) SetColorPath(code string) {
+	o.ColorCodePath = code
+}
+
+func (o *OutputOption) SetColorMatch(code string) {
+	o.ColorCodeMatch = code
 }
 
 // Search options.


### PR DESCRIPTION
I added color code options, `--color-line-number`, `--color-match` and `--color-path`.

You can use like the following:

```sh
$ pt --color-path="1;34" PATTERN
```

If you want to specify the options always, you can add the options to [`.ptconfig.toml`.](https://github.com/monochromegane/the_platinum_searcher#ptconfigtoml)

```toml
color-path = "1;34"
```

see also: [ANSI Escape sequences - Set Graphics Mode:](http://ascii-table.com/ansi-escape-sequences.php)

### Related issues

- https://github.com/monochromegane/the_platinum_searcher/issues/117
- https://github.com/monochromegane/the_platinum_searcher/pull/129