### PR TITLE
Allow '..' as an argument to 'pt'

### DIFF
--- a/find.go
+++ b/find.go
@@ -109,5 +109,8 @@ func (f find) findFile(root string, regexp *regexp.Regexp) {
 }
 
 func isHidden(name string) bool {
+	if name == "." || name == ".." {
+		return false
+	}
 	return len(name) > 1 && name[0] == '.'
 }


### PR DESCRIPTION
The current version of the isHidden function will tag ".." as a hidden file. I commonly use 'pt ..' to expand the scope of a search.

Please take a look.