### PR TITLE
Simplify grepper interface

### DIFF
--- a/extended_grep.go
+++ b/extended_grep.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"log"
 	"os"
-	"sync"
 )
 
 type extendedGrep struct {
@@ -12,7 +11,7 @@ type extendedGrep struct {
 	pattern pattern
 }
 
-func (g extendedGrep) grep(path string, sem chan struct{}, wg *sync.WaitGroup) {
+func (g extendedGrep) grep(path string) {
 	f, err := getFileHandler(path)
 	if err != nil {
 		log.Fatalf("open: %s\n", err)
@@ -20,8 +19,6 @@ func (g extendedGrep) grep(path string, sem chan struct{}, wg *sync.WaitGroup) {
 
 	defer func() {
 		f.Close()
-		<-sem
-		wg.Done()
 	}()
 
 	if f == os.Stdin {

--- a/extended_grep.go
+++ b/extended_grep.go
@@ -16,10 +16,7 @@ func (g extendedGrep) grep(path string) {
 	if err != nil {
 		log.Fatalf("open: %s\n", err)
 	}
-
-	defer func() {
-		f.Close()
-	}()
+	defer f.Close()
 
 	if f == os.Stdin {
 		// TODO: File type is fixed in ASCII because it can not determine the character code.

--- a/fixed_grep.go
+++ b/fixed_grep.go
@@ -18,10 +18,7 @@ func (g fixedGrep) grep(path string) {
 	if err != nil {
 		log.Fatalf("open: %s\n", err)
 	}
-
-	defer func() {
-		f.Close()
-	}()
+	defer f.Close()
 
 	if f == os.Stdin {
 		// TODO: File type is fixed in ASCII because it can not determine the character code.

--- a/fixed_grep.go
+++ b/fixed_grep.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
-	"sync"
 )
 
 type fixedGrep struct {
@@ -14,7 +13,7 @@ type fixedGrep struct {
 	pattern pattern
 }
 
-func (g fixedGrep) grep(path string, sem chan struct{}, wg *sync.WaitGroup) {
+func (g fixedGrep) grep(path string) {
 	f, err := getFileHandler(path)
 	if err != nil {
 		log.Fatalf("open: %s\n", err)
@@ -22,8 +21,6 @@ func (g fixedGrep) grep(path string, sem chan struct{}, wg *sync.WaitGroup) {
 
 	defer func() {
 		f.Close()
-		<-sem
-		wg.Done()
 	}()
 
 	if f == os.Stdin {

--- a/passthrough_grep.go
+++ b/passthrough_grep.go
@@ -1,16 +1,10 @@
 package the_platinum_searcher
 
-import "sync"
-
 type passthroughGrep struct {
 	printer printer
 }
 
-func (g passthroughGrep) grep(path string, sem chan struct{}, wg *sync.WaitGroup) {
-	defer func() {
-		<-sem
-		wg.Done()
-	}()
+func (g passthroughGrep) grep(path string) {
 	match := match{path: path, lines: []line{line{}}}
 	g.printer.print(match)
 }


### PR DESCRIPTION
Throttling and synchronization can be done without duplicating the same
logic in various greppers.