### PR TITLE
support --null option compatible with ag

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -25,7 +25,7 @@ func newFormatPrinter(pattern pattern, w io.Writer, opts Option) formatPrinter {
 	case opts.OutputOption.Count:
 		return count{decorator: decorator, w: writer}
 	case opts.OutputOption.EnableGroup:
-		return group{decorator: decorator, w: writer}
+		return group{decorator: decorator, w: writer, useNull: opts.OutputOption.EnableNull}
 	default:
 		return noGroup{decorator: decorator, w: writer}
 	}
@@ -75,10 +75,17 @@ func (f count) print(match match) {
 type group struct {
 	w         io.Writer
 	decorator decorator
+	useNull   bool
 }
 
 func (f group) print(match match) {
-	fmt.Fprintln(f.w, f.decorator.path(match.path))
+	if f.useNull {
+		fmt.Fprint(f.w, f.decorator.path(match.path))
+		fmt.Fprint(f.w, "\x00")
+	} else {
+		fmt.Fprintln(f.w, f.decorator.path(match.path))
+	}
+
 	for _, line := range match.lines {
 		sep := SeparatorColon
 		if !line.matched {

--- a/option.go
+++ b/option.go
@@ -22,6 +22,8 @@ type OutputOption struct {
 	ColorCodePath       string       // Color path names. Not user option.
 	ColorCodeMatch      string       // Color result matches. Not user option.
 	Group               func()       `long:"group" description:"Print file name at header (default: true)"`
+	Null                func()       `long:"null" description:"Separate filenames with null (for 'xargs -0') (default: false)"`
+	EnableNull          bool         // Enable null. Not user option.
 	NoGroup             func()       `long:"nogroup" description:"Don't print file name at header (default: false)"`
 	ForceGroup          bool         // Force group. Not user option.
 	EnableGroup         bool         // Enable group. Not user option.
@@ -51,8 +53,14 @@ func newOutputOption() *OutputOption {
 	opt.ColorCodeLineNumber = "1;33" // yellow with black background
 	opt.ColorCodePath = "1;32"       // bold green
 	opt.ColorCodeMatch = "30;43"     // black with yellow background
+	opt.Null = opt.SetNull
+	opt.EnableNull = false
 
 	return opt
+}
+
+func (o *OutputOption) SetNull() {
+	o.EnableNull = true
 }
 
 func (o *OutputOption) SetEnableColor() {


### PR DESCRIPTION
ag (https://github.com/ggreer/the_silver_searcher) supports the --null option which uses  a null character instead of a newline after the filename in a search result.This can be useful when using xargs -0 to avoid problems with "exotic" characters in filenames.  

This pull request implements the same for pg. This has only an effect if grouping is turned on.
My original motivation to implement this, was to make
https://github.com/aykamko/tag
work, which now does (also using ag is still hardcoded in tag), but this option might  also be useful in other use cases. 