### PR TITLE
Null option are now effected with l option.

### DIFF
--- a/formatter.go
+++ b/formatter.go
@@ -21,11 +21,11 @@ func newFormatPrinter(pattern pattern, w io.Writer, opts Option) formatPrinter {
 	case opts.SearchOption.SearchStream:
 		return matchLine{decorator: decorator, w: writer}
 	case opts.OutputOption.FilesWithMatches:
-		return fileWithMatch{decorator: decorator, w: writer}
+		return fileWithMatch{decorator: decorator, w: writer, useNull: opts.OutputOption.Null}
 	case opts.OutputOption.Count:
 		return count{decorator: decorator, w: writer}
 	case opts.OutputOption.EnableGroup:
-		return group{decorator: decorator, w: writer, useNull: opts.OutputOption.EnableNull}
+		return group{decorator: decorator, w: writer, useNull: opts.OutputOption.Null}
 	default:
 		return noGroup{decorator: decorator, w: writer}
 	}
@@ -52,10 +52,16 @@ func (f matchLine) print(match match) {
 type fileWithMatch struct {
 	w         io.Writer
 	decorator decorator
+	useNull   bool
 }
 
 func (f fileWithMatch) print(match match) {
-	fmt.Fprintln(f.w, f.decorator.path(match.path))
+	if f.useNull {
+		fmt.Fprint(f.w, f.decorator.path(match.path))
+		fmt.Fprint(f.w, "\x00")
+	} else {
+		fmt.Fprintln(f.w, f.decorator.path(match.path))
+	}
 }
 
 type count struct {

--- a/option.go
+++ b/option.go
@@ -22,8 +22,7 @@ type OutputOption struct {
 	ColorCodePath       string       // Color path names. Not user option.
 	ColorCodeMatch      string       // Color result matches. Not user option.
 	Group               func()       `long:"group" description:"Print file name at header (default: true)"`
-	Null                func()       `long:"null" description:"Separate filenames with null (for 'xargs -0') (default: false)"`
-	EnableNull          bool         // Enable null. Not user option.
+	Null                bool         `short:"0" long:"null" description:"Separate filenames with null (for 'xargs -0') (default: false)"`
 	NoGroup             func()       `long:"nogroup" description:"Don't print file name at header (default: false)"`
 	ForceGroup          bool         // Force group. Not user option.
 	EnableGroup         bool         // Enable group. Not user option.
@@ -53,14 +52,8 @@ func newOutputOption() *OutputOption {
 	opt.ColorCodeLineNumber = "1;33" // yellow with black background
 	opt.ColorCodePath = "1;32"       // bold green
 	opt.ColorCodeMatch = "30;43"     // black with yellow background
-	opt.Null = opt.SetNull
-	opt.EnableNull = false
 
 	return opt
-}
-
-func (o *OutputOption) SetNull() {
-	o.EnableNull = true
 }
 
 func (o *OutputOption) SetEnableColor() {


### PR DESCRIPTION
refs: https://github.com/monochromegane/the_platinum_searcher/pull/143

> I think this should have an effect when passed -l option.
Because xargs -0 option expect filenames.


**Before**

It dosen't work.

```sh
go run cmd/pt/main.go --null -l go
README.md
Godeps/Godeps.json
decoder.go
encoder.go
find.go
platinum_searcher.go
formatter.go
search.go
files/ascii.txt
walk.go
formatter_test.go
grep.go
wercker.yml
line_grep_test.go
grep_test.go
ignore.go
option.go
files/vcs/match/match.txt
find_test.go
files/vcs/ignore/ignore.txt
files/ja/broken_utf8.txt
files/ja/broken_shift_jis.txt
files/depth/file_1.txt
files/vcs/match/ignore.txt
files/ja/euc-jp.txt
files/ja/utf8.txt
files/ja/shift_jis.txt
files/depth/dir_1/file_2.txt
files/context/context.txt
files/vcs/absolute/ignore.txt
files/ja/broken_euc-jp.txt
files/depth/dir_1/dir_2/file_3.txt
```

**After**

It works.

```sh
go run cmd/pt/main.go -0 -l go
encoder.godecoder.goGodeps/Godeps.jsonline_grep_test.goplatinum_searcher.gosearch.gooption.gowalk.gofind.goREADME.mdfind_test.gogrep.gowercker.ymlfiles/vcs/match/match.txtformatter.gogrep_test.goformatter_test.goignore.gofiles/ascii.txtfiles/depth/file_1.txtfiles/vcs/ignore/ignore.txtfiles/ja/utf8.txtfiles/context/context.txtfiles/vcs/match/ignore.txtfiles/ja/broken_shift_jis.txtfiles/ja/broken_utf8.txtfiles/ja/euc-jp.txtfiles/ja/broken_euc-jp.txtfiles/depth/dir_1/file_2.txtfiles/ja/shift_jis.txtfiles/vcs/absolute/ignore.txtfiles/depth/dir_1/dir_2/file_3.txt
```