### PR TITLE
Little fix, that may improve overall speed

### DIFF
--- a/platinum_searcher.go
+++ b/platinum_searcher.go
@@ -31,7 +31,7 @@ func (p PlatinumSearcher) Run(args []string) int {
 
 	conflag.LongHyphen = true
 	conflag.BoolValue = false
-	for _, c := range []string{
+	for _, c := range [...]string{
 		filepath.Join(os.Getenv("XDG_CONFIG_HOME"), "pt", "config.toml"),
 		filepath.Join(home.Dir(), ".ptconfig.toml"),
 		".ptconfig.toml",


### PR DESCRIPTION
At first the change may seems of a little significance, but it may speed up a start up time. Here we have a list of known-size elements, so why allocate more heavy slice type for them? Array type in this context does great job, without unnecessary "just in case" memory allocation.
