### PR TITLE
Add snap packaging.

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,24 @@
+name: pt
+version: v2.1.4
+summary: The Platinum Searcher
+description: |
+  A code search tool similar to ack and the_silver_searcher(ag). It supports multi platforms and multi encodings.
+
+grade: stable # must be 'stable' to release into candidate/stable channels
+confinement: strict # use 'strict' once you have the right plugs and slots
+
+apps:
+    pt:
+        command: bin/pt
+        plugs:
+            - home
+
+parts:
+  gobuild:
+    # See 'snapcraft plugins'
+    plugin: go
+    source: https://github.com/monochromegane/the_platinum_searcher
+    source-type: git
+    source-tag: v2.1.4
+    go-packages:
+        - github.com/monochromegane/the_platinum_searcher/cmd/pt


### PR DESCRIPTION
This adds [snap](http://snapcraft.io) packaging for the platinum searcher.

To build the snap, install snapcraft (see link above), and run:

```
$ snapcraft
```

in this directory. Then `sudo snap install pt_v2.1.4_amd64.snap --force-dangerous` to try it out. No need to fear the flag there, that just means you're loading an unsigned package. To get it legit, we'll need to publish it to the snap store.

I've been using `pt` for a couple years now and shudder at the dark days when I used to `grep -r`. Would be happy to assist with publishing, and integrating that into your CI & release process.
