### PR TITLE
ExitCodeOK, when user set --help flag explicitly

### DIFF
--- a/platinum_searcher.go
+++ b/platinum_searcher.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/jessevdk/go-flags"
 	"github.com/monochromegane/conflag"
 	"github.com/monochromegane/go-home"
 	"github.com/monochromegane/terminal"
@@ -43,6 +44,9 @@ func (p PlatinumSearcher) Run(args []string) int {
 
 	args, err := parser.ParseArgs(args)
 	if err != nil {
+		if ferr, ok := err.(*flags.Error); ok && ferr.Type == flags.ErrHelp {
+			return ExitCodeOK
+		}
 		return ExitCodeError
 	}
 


### PR DESCRIPTION
It may be confusing, when `pt --help` returns ExitCodeError, while there is no any indication of error. `pt --help` should return normally in my opinion. If you agree, I encourage you to accept the pull request.