### PR TITLE
Fix not display issue of before option

### DIFF
--- a/line_grep.go
+++ b/line_grep.go
@@ -61,6 +61,8 @@ func (g lineGrep) grepEachLines(f *os.File, encoding int, matchFn matchFunc, cou
 						// append after line.
 						match.add(lineNum, 0, scanner.Text(), matched)
 						afterCount++
+					} else if g.before > 0 && g.after == 0 {
+						beforeMatches = g.storeBeforeMatch(beforeMatches, lineNum, scanner.Text(), matched)
 					}
 					if afterCount >= g.after {
 						// reset to before match

--- a/line_grep_test.go
+++ b/line_grep_test.go
@@ -37,6 +37,21 @@ files/context/context.txt:8-after
 	}
 }
 
+// Regression test of https://github.com/monochromegane/the_platinum_searcher/issues/166
+func TestLineGrepBefore(t *testing.T) {
+	opts := defaultOption()
+	opts.OutputOption.Before = 1
+
+	expect := `files/context/context.txt:3-before
+files/context/context.txt:4:go test
+files/context/context.txt:5-after
+files/context/context.txt:6:go test
+`
+	if !assertLineGrep(opts, "files/context/context.txt", expect) {
+		t.Errorf("Failed line grep (before).")
+	}
+}
+
 func assertLineGrep(opts Option, path string, expect string) bool {
 	buf := new(bytes.Buffer)
 	printer := newPrinter(pattern{}, buf, opts)


### PR DESCRIPTION
This is related to #166.

In original code, the line which is both next line from matched line
and before line of next matched line is not displayed. If before option
is enabled then store line in after context.

##### Before

```
% echo 'a1\nb\nc1' | pt -B1 1
a1
c1
```

##### With this patch

```
%  echo 'a1\nb\nc1' | pt -B1 1
a1
b
c1
```