### PR TITLE
Add file type options

### DIFF
--- a/file_types.go
+++ b/file_types.go
@@ -1,0 +1,428 @@
+package the_platinum_searcher
+
+import (
+	"fmt"
+	"strings"
+)
+
+// fileTypeSearchPattern builds a regexp pattern for any requested file types.
+// If no file types were requested, an empty string is returned.
+func fileTypeSearchPattern() string {
+	var exts []string
+
+	if opts.FileTypeOption.ActionScript {
+		exts = append(exts, []string{"as", "mxml"}...)
+	}
+	if opts.FileTypeOption.Ada {
+		exts = append(exts, []string{"ada", "abd", "ads"}...)
+	}
+	if opts.FileTypeOption.Asm {
+		exts = append(exts, []string{"asm", "s"}...)
+	}
+	if opts.FileTypeOption.Batch {
+		exts = append(exts, []string{"bat", "cmd"}...)
+	}
+	if opts.FileTypeOption.Bitbake {
+		exts = append(exts, []string{"bb", "bbappend", "bbclass", "inc"}...)
+	}
+	if opts.FileTypeOption.Bro {
+		exts = append(exts, []string{"bro", "bif"}...)
+	}
+	if opts.FileTypeOption.CC {
+		exts = append(exts, []string{"c", "h", "xs"}...)
+	}
+	if opts.FileTypeOption.Cfmx {
+		exts = append(exts, []string{"cfc", "cfm", "cfml"}...)
+	}
+	if opts.FileTypeOption.Chpl {
+		exts = append(exts, "chpl")
+	}
+	if opts.FileTypeOption.Clojure {
+		exts = append(exts, []string{"clj", "cljs", "cljc", "cljx"}...)
+	}
+	if opts.FileTypeOption.Coffee {
+		exts = append(exts, []string{"coffee", "cjsx"}...)
+	}
+	if opts.FileTypeOption.Cpp {
+		exts = append(exts, []string{"cpp", "cc", "C", "cxx", "m", "hpp", "hh", "h", "H", "hxx", "tpp"}...)
+	}
+	if opts.FileTypeOption.Crystal {
+		exts = append(exts, []string{"cr", "ecr"}...)
+	}
+	if opts.FileTypeOption.Csharp {
+		exts = append(exts, "cs")
+	}
+	if opts.FileTypeOption.CSS {
+		exts = append(exts, "css")
+	}
+	if opts.FileTypeOption.Cython {
+		exts = append(exts, []string{"pyx", "pxd", "pxi"}...)
+	}
+	if opts.FileTypeOption.Delphi {
+		exts = append(exts, []string{"pas", "int", "dfm", "nfm", "dof", "dpk", "dpr", "dproj", "groupproj", "bdsgroup", "bdsproj"}...)
+	}
+	if opts.FileTypeOption.Ebuild {
+		exts = append(exts, []string{"ebuild", "eclass"}...)
+	}
+	if opts.FileTypeOption.Elisp {
+		exts = append(exts, "el")
+	}
+	if opts.FileTypeOption.Elixer {
+		exts = append(exts, []string{"ex", "eex", "exs"}...)
+	}
+	if opts.FileTypeOption.Erlang {
+		exts = append(exts, []string{"erl", "hrl"}...)
+	}
+	if opts.FileTypeOption.Factor {
+		exts = append(exts, "factor")
+	}
+	if opts.FileTypeOption.Fortran {
+		exts = append(exts, []string{"f", "f77", "f90", "f95", "f03", "for", "ftn", "fpp"}...)
+	}
+	if opts.FileTypeOption.Fsharp {
+		exts = append(exts, []string{"fs", "fsi", "fsx"}...)
+	}
+	if opts.FileTypeOption.GetText {
+		exts = append(exts, []string{"po", "pot", "mo"}...)
+	}
+	if opts.FileTypeOption.Glsl {
+		exts = append(exts, []string{"vert", "tesc", "tese", "geom", "frag", "comp"}...)
+	}
+	if opts.FileTypeOption.Go {
+		exts = append(exts, "go")
+	}
+	if opts.FileTypeOption.Groovy {
+		exts = append(exts, []string{"groovy", "gtmpl", "gpp", "grunit"}...)
+	}
+	if opts.FileTypeOption.Haml {
+		exts = append(exts, "haml")
+	}
+	if opts.FileTypeOption.Haskell {
+		exts = append(exts, []string{"hs", "lhs"}...)
+	}
+	if opts.FileTypeOption.HH {
+		exts = append(exts, "h")
+	}
+	if opts.FileTypeOption.HTML {
+		exts = append(exts, []string{"htm", "html", "shtml", "xhtml"}...)
+	}
+	if opts.FileTypeOption.INI {
+		exts = append(exts, "ini")
+	}
+	if opts.FileTypeOption.Jade {
+		exts = append(exts, "jade")
+	}
+	if opts.FileTypeOption.Java {
+		exts = append(exts, []string{"java", "properties"}...)
+	}
+	if opts.FileTypeOption.JS {
+		exts = append(exts, []string{"js", "jsx", "vue"}...)
+	}
+	if opts.FileTypeOption.JSON {
+		exts = append(exts, "json")
+	}
+	if opts.FileTypeOption.Jsp {
+		exts = append(exts, []string{"jsp", "jspx", "jhtm", "jhtml"}...)
+	}
+	if opts.FileTypeOption.Julia {
+		exts = append(exts, "jl")
+	}
+	if opts.FileTypeOption.Kotlin {
+		exts = append(exts, "kt")
+	}
+	if opts.FileTypeOption.Less {
+		exts = append(exts, "less")
+	}
+	if opts.FileTypeOption.Liquid {
+		exts = append(exts, "liquid")
+	}
+	if opts.FileTypeOption.Lisp {
+		exts = append(exts, []string{"lisp", "lsp"}...)
+	}
+	if opts.FileTypeOption.Log {
+		exts = append(exts, "log")
+	}
+	if opts.FileTypeOption.Lua {
+		exts = append(exts, "lua")
+	}
+	if opts.FileTypeOption.M4 {
+		exts = append(exts, "m4")
+	}
+	if opts.FileTypeOption.Make {
+		exts = append(exts, []string{"Makefiles", "mk", "mak"}...)
+	}
+	if opts.FileTypeOption.Mako {
+		exts = append(exts, "mako")
+	}
+	if opts.FileTypeOption.Markdown {
+		exts = append(exts, []string{"markdown", "mdown", "mdwn", "mkdn", "mkd", "md"}...)
+	}
+	if opts.FileTypeOption.Mason {
+		exts = append(exts, []string{"mas", "mhtml", "mpl", "mtxt"}...)
+	}
+	if opts.FileTypeOption.Matlab {
+		exts = append(exts, "m")
+	}
+	if opts.FileTypeOption.Mathematica {
+		exts = append(exts, []string{"m", "wl"}...)
+	}
+	if opts.FileTypeOption.Mercury {
+		exts = append(exts, []string{"m", "moo"}...)
+	}
+	if opts.FileTypeOption.Nim {
+		exts = append(exts, "nim")
+	}
+	if opts.FileTypeOption.ObjC {
+		exts = append(exts, []string{"m", "h"}...)
+	}
+	if opts.FileTypeOption.ObjCpp {
+		exts = append(exts, []string{"mm", "h"}...)
+	}
+	if opts.FileTypeOption.OCaml {
+		exts = append(exts, []string{"ml", "mli", "mll", "mly"}...)
+	}
+	if opts.FileTypeOption.Octave {
+		exts = append(exts, "m")
+	}
+	if opts.FileTypeOption.Parrot {
+		exts = append(exts, []string{"pir", "pasm", "pmc", "ops", "pod", "pg", "tg"}...)
+	}
+	if opts.FileTypeOption.Perl {
+		exts = append(exts, []string{"pl", "pm", "pm6", "pod", "t"}...)
+	}
+	if opts.FileTypeOption.PHP {
+		exts = append(exts, []string{"php", "phpt", "php3", "php4", "php5", "phtml"}...)
+	}
+	if opts.FileTypeOption.Pike {
+		exts = append(exts, []string{"pike", "pmod"}...)
+	}
+	if opts.FileTypeOption.Plone {
+		exts = append(exts, []string{"pt", "cpt", "metadata", "cpy", "py", "xml", "zcml"}...)
+	}
+	if opts.FileTypeOption.Proto {
+		exts = append(exts, "proto")
+	}
+	if opts.FileTypeOption.Puppet {
+		exts = append(exts, "pp")
+	}
+	if opts.FileTypeOption.Python {
+		exts = append(exts, "py")
+	}
+	if opts.FileTypeOption.QML {
+		exts = append(exts, "qml")
+	}
+	if opts.FileTypeOption.Racket {
+		exts = append(exts, []string{"rkt", "ss", "scm"}...)
+	}
+	if opts.FileTypeOption.Rake {
+		exts = append(exts, "Rakefile")
+	}
+	if opts.FileTypeOption.RestructuredText {
+		exts = append(exts, "rst")
+	}
+	if opts.FileTypeOption.RS {
+		exts = append(exts, "rs")
+	}
+	if opts.FileTypeOption.R {
+		exts = append(exts, []string{"R", "Rmd", "Rnw", "Rtex", "Rrst"}...)
+	}
+	if opts.FileTypeOption.Rdoc {
+		exts = append(exts, "rdoc")
+	}
+	if opts.FileTypeOption.Ruby {
+		exts = append(exts, []string{"rb", "rhtml", "rjs", "rxml", "erb", "rake", "spec"}...)
+	}
+	if opts.FileTypeOption.Rust {
+		exts = append(exts, "rs")
+	}
+	if opts.FileTypeOption.Salt {
+		exts = append(exts, "sls")
+	}
+	if opts.FileTypeOption.Sass {
+		exts = append(exts, []string{"sass", "scss"}...)
+	}
+	if opts.FileTypeOption.Scala {
+		exts = append(exts, "scala")
+	}
+	if opts.FileTypeOption.Scheme {
+		exts = append(exts, []string{"scm", "ss"}...)
+	}
+	if opts.FileTypeOption.Shell {
+		exts = append(exts, []string{"sh", "bash", "csh", "tcsh", "ksh", "zsh", "fish"}...)
+	}
+	if opts.FileTypeOption.Smalltalk {
+		exts = append(exts, "st")
+	}
+	if opts.FileTypeOption.SML {
+		exts = append(exts, []string{"sml", "fun", "mlb", "sig"}...)
+	}
+	if opts.FileTypeOption.SQL {
+		exts = append(exts, []string{"sql", "ctl"}...)
+	}
+	if opts.FileTypeOption.Stylus {
+		exts = append(exts, "styl")
+	}
+	if opts.FileTypeOption.Swift {
+		exts = append(exts, "swift")
+	}
+	if opts.FileTypeOption.TCL {
+		exts = append(exts, []string{"tcl", "itcl", "itk"}...)
+	}
+	if opts.FileTypeOption.Tex {
+		exts = append(exts, []string{"tex", "cls", "sty"}...)
+	}
+	if opts.FileTypeOption.TT {
+		exts = append(exts, []string{"tt", "tt2", "ttml"}...)
+	}
+	if opts.FileTypeOption.TOML {
+		exts = append(exts, "toml")
+	}
+	if opts.FileTypeOption.TS {
+		exts = append(exts, []string{"ts", "tsx"}...)
+	}
+	if opts.FileTypeOption.Vala {
+		exts = append(exts, []string{"vala", "vapi"}...)
+	}
+	if opts.FileTypeOption.VB {
+		exts = append(exts, []string{"bas", "cls", "frm", "ctl", "vb", "resx"}...)
+	}
+	if opts.FileTypeOption.Velocity {
+		exts = append(exts, []string{"vm", "vtl", "vsl"}...)
+	}
+	if opts.FileTypeOption.Verilog {
+		exts = append(exts, []string{"v", "vh", "sv"}...)
+	}
+	if opts.FileTypeOption.VHDL {
+		exts = append(exts, []string{"vhd", "vhdl"}...)
+	}
+	if opts.FileTypeOption.Vim {
+		exts = append(exts, "vim")
+	}
+	if opts.FileTypeOption.Wix {
+		exts = append(exts, []string{"wxi", "wxs"}...)
+	}
+	if opts.FileTypeOption.WSDL {
+		exts = append(exts, "wsdl")
+	}
+	if opts.FileTypeOption.WADL {
+		exts = append(exts, "wadl")
+	}
+	if opts.FileTypeOption.XML {
+		exts = append(exts, []string{"xml", "dtd", "xsl", "xslt", "ent", "tld"}...)
+	}
+	if opts.FileTypeOption.YAML {
+		exts = append(exts, []string{"yaml", "yml"}...)
+	}
+
+	if len(exts) == 0 {
+		return ""
+	}
+	return `\.(` + strings.Join(exts, "|") + `)$`
+}
+
+func printFileTypeOptions() {
+	fmt.Printf(`The following file type options are available:
+
+      --actionscript        .as .mxml
+      --ada                 .ada .abd .ads
+      --asm                 .asm .s
+      --batch               .bat .cmd
+      --bitbake             .bb .bbappend .bbclass .inc
+      --bro                 .bro .bif
+      --cc                  .c .h .xs
+      --cfmx                .cfc .cfm .cfml
+      --chpl                .chpl
+      --clojure             .clj .cljs .cljc .cljx
+      --coffee              .coffee .cjsx
+      --cpp                 .cpp .cc .C .cxx .m .hpp .hh .h .H .hxx .tpp
+      --crystal             .cr .ecr
+      --csharp              .cs
+      --css                 .css
+      --cython              .pyx .pxd .pxi
+      --delphi              .pas .int .dfm .nfm .dof .dpk .dpr .dproj .groupproj .bdsgroup .bdsproj
+      --ebuild              .ebuild .eclass
+      --elisp               .el
+      --elixer              .ex .eex .exs
+      --erlang              .erl .hrl
+      --factor              .factor
+      --fortran             .f .f77 .f90 .f95 .f03 .for .ftn .fpp
+      --fsharp              .fs .fsi .fsx
+      --gettext             .po .pot .mo
+      --glsl                .vert .tesc .tese .geom .frag .comp
+      --go                  .go
+      --groovy              .groovy .gtmpl .gpp .grunit
+      --haml                .haml
+      --haskell             .hs .lhs
+      --hh                  .h
+      --html                .htm .html .shtml .xhtml
+      --ini                 .ini
+      --jade                .jade
+      --java                .java .properties
+      --js                  .js .jsx .vue
+      --json                .json
+      --jsp                 .jsp .jspx .jhtm .jhtml
+      --julia               .jl
+      --kotlin              .kt
+      --less                .less
+      --liquid              .liquid
+      --lisp                .lisp .lsp
+      --log                 .log
+      --lua                 .lua
+      --m4                  .m4
+      --make                .Makefiles .mk .mak
+      --mako                .mako
+      --markdown            .markdown .mdown .mdwn .mkdn .mkd .md
+      --mason               .mas .mhtml .mpl .mtxt
+      --matlab              .m
+      --mathematica         .m .wl
+      --mercury             .m .moo
+      --nim                 .nim
+      --objc                .m .h
+      --objcpp              .mm .h
+      --ocaml               .ml .mli .mll .mly
+      --octave              .m
+      --parrot              .pir .pasm .pmc .ops .pod .pg .tg
+      --perl                .pl .pm .pm6 .pod .t
+      --php                 .php .phpt .php3 .php4 .php5 .phtml
+      --pike                .pike .pmod
+      --plone               .pt .cpt .metadata .cpy .py .xml .zcml
+      --proto               .proto
+      --puppet              .pp
+      --python              .py
+      --qml                 .qml
+      --racket              .rkt .ss .scm
+      --rake                .Rakefile
+      --restructuredtext    .rst
+      --rs                  .rs
+      --r                   .R .Rmd .Rnw .Rtex .Rrst
+      --rdoc                .rdoc
+      --ruby                .rb .rhtml .rjs .rxml .erb .rake .spec
+      --rust                .rs
+      --salt                .sls
+      --sass                .sass .scss
+      --scala               .scala
+      --scheme              .scm .ss
+      --shell               .sh .bash .csh .tcsh .ksh .zsh .fish
+      --smalltalk           .st
+      --sml                 .sml .fun .mlb .sig
+      --sql                 .sql .ctl
+      --stylus              .styl
+      --swift               .swift
+      --tcl                 .tcl .itcl .itk
+      --tex                 .tex .cls .sty
+      --tt                  .tt .tt2 .ttml
+      --toml                .toml
+      --ts                  .ts .tsx
+      --vala                .vala .vapi
+      --vb                  .bas .cls .frm .ctl .vb .resx
+      --velocity            .vm .vtl .vsl
+      --verilog             .v .vh .sv
+      --vhdl                .vhd .vhdl
+      --vim                 .vim
+      --wix                 .wxi .wxs
+      --wsdl                .wsdl
+      --wadl                .wadl
+      --xml                 .xml .dtd .xsl .xslt .ent .tld
+      --yaml                .yaml .yml
+`)
+}

--- a/option.go
+++ b/option.go
@@ -4,9 +4,10 @@ import "github.com/jessevdk/go-flags"
 
 // Top level options
 type Option struct {
-	Version      bool          `long:"version" description:"Show version"`
-	OutputOption *OutputOption `group:"Output Options"`
-	SearchOption *SearchOption `group:"Search Options"`
+	Version        bool            `long:"version" description:"Show version"`
+	OutputOption   *OutputOption   `group:"Output Options"`
+	SearchOption   *SearchOption   `group:"Search Options"`
+	FileTypeOption *FileTypeOption `group:"File Type Options"`
 }
 
 // Output options.
@@ -135,6 +136,118 @@ func newSearchOption() *SearchOption {
 	return opt
 }
 
+// File Type options.
+type FileTypeOption struct {
+	ListFileTypes bool `long:"list-file-types" description:"List available file type options"`
+
+	ActionScript     bool `hidden:"true" long:"actionscript" description:".as .mxml"`
+	Ada              bool `hidden:"true" long:"ada" description:".ada .abd .ads"`
+	Asm              bool `hidden:"true" long:"asm" description:".asm .s"`
+	Batch            bool `hidden:"true" long:"batch" description:".bat .cmd"`
+	Bitbake          bool `hidden:"true" long:"bitbake" description:".bb .bbappend .bbclass .inc"`
+	Bro              bool `hidden:"true" long:"bro" description:".bro .bif"`
+	CC               bool `hidden:"true" long:"cc" description:".c .h .xs"`
+	Cfmx             bool `hidden:"true" long:"cfmx" description:".cfc .cfm .cfml"`
+	Chpl             bool `hidden:"true" long:"chpl" description:".chpl"`
+	Clojure          bool `hidden:"true" long:"clojure" description:".clj .cljs .cljc .cljx"`
+	Coffee           bool `hidden:"true" long:"coffee" description:".coffee .cjsx"`
+	Cpp              bool `hidden:"true" long:"cpp" description:".cpp .cc .C .cxx .m .hpp .hh .h .H .hxx .tpp"`
+	Crystal          bool `hidden:"true" long:"crystal" description:".cr .ecr"`
+	Csharp           bool `hidden:"true" long:"csharp" description:".cs"`
+	CSS              bool `hidden:"true" long:"css" description:".css"`
+	Cython           bool `hidden:"true" long:"cython" description:".pyx .pxd .pxi"`
+	Delphi           bool `hidden:"true" long:"delphi" description:".pas .int .dfm .nfm .dof .dpk .dpr .dproj .groupproj .bdsgroup .bdsproj"`
+	Ebuild           bool `hidden:"true" long:"ebuild" description:".ebuild .eclass"`
+	Elisp            bool `hidden:"true" long:"elisp" description:".el"`
+	Elixer           bool `hidden:"true" long:"elixer" description:".ex .eex .exs"`
+	Erlang           bool `hidden:"true" long:"erlang" description:".erl .hrl"`
+	Factor           bool `hidden:"true" long:"factor" description:".factor"`
+	Fortran          bool `hidden:"true" long:"fortran" description:".f .f77 .f90 .f95 .f03 .for .ftn .fpp"`
+	Fsharp           bool `hidden:"true" long:"fsharp" description:".fs .fsi .fsx"`
+	GetText          bool `hidden:"true" long:"gettext" description:".po .pot .mo"`
+	Glsl             bool `hidden:"true" long:"glsl" description:".vert .tesc .tese .geom .frag .comp"`
+	Go               bool `hidden:"true" long:"go" description:".go"`
+	Groovy           bool `hidden:"true" long:"groovy" description:".groovy .gtmpl .gpp .grunit"`
+	Haml             bool `hidden:"true" long:"haml" description:".haml"`
+	Haskell          bool `hidden:"true" long:"haskell" description:".hs .lhs"`
+	HH               bool `hidden:"true" long:"hh" description:".h"`
+	HTML             bool `hidden:"true" long:"html" description:".htm .html .shtml .xhtml"`
+	INI              bool `hidden:"true" long:"ini" description:".ini"`
+	Jade             bool `hidden:"true" long:"jade" description:".jade"`
+	Java             bool `hidden:"true" long:"java" description:".java .properties"`
+	JS               bool `hidden:"true" long:"js" description:".js .jsx .vue"`
+	JSON             bool `hidden:"true" long:"json" description:".json"`
+	Jsp              bool `hidden:"true" long:"jsp" description:".jsp .jspx .jhtm .jhtml"`
+	Julia            bool `hidden:"true" long:"julia" description:".jl"`
+	Kotlin           bool `hidden:"true" long:"kotlin" description:".kt"`
+	Less             bool `hidden:"true" long:"less" description:".less"`
+	Liquid           bool `hidden:"true" long:"liquid" description:".liquid"`
+	Lisp             bool `hidden:"true" long:"lisp" description:".lisp .lsp"`
+	Log              bool `hidden:"true" long:"log" description:".log"`
+	Lua              bool `hidden:"true" long:"lua" description:".lua"`
+	M4               bool `hidden:"true" long:"m4" description:".m4"`
+	Make             bool `hidden:"true" long:"make" description:".Makefiles .mk .mak"`
+	Mako             bool `hidden:"true" long:"mako" description:".mako"`
+	Markdown         bool `hidden:"true" long:"markdown" description:".markdown .mdown .mdwn .mkdn .mkd .md"`
+	Mason            bool `hidden:"true" long:"mason" description:".mas .mhtml .mpl .mtxt"`
+	Matlab           bool `hidden:"true" long:"matlab" description:".m"`
+	Mathematica      bool `hidden:"true" long:"mathematica" description:".m .wl"`
+	Mercury          bool `hidden:"true" long:"mercury" description:".m .moo"`
+	Nim              bool `hidden:"true" long:"nim" description:".nim"`
+	ObjC             bool `hidden:"true" long:"objc" description:".m .h"`
+	ObjCpp           bool `hidden:"true" long:"objcpp" description:".mm .h"`
+	OCaml            bool `hidden:"true" long:"ocaml" description:".ml .mli .mll .mly"`
+	Octave           bool `hidden:"true" long:"octave" description:".m"`
+	Parrot           bool `hidden:"true" long:"parrot" description:".pir .pasm .pmc .ops .pod .pg .tg"`
+	Perl             bool `hidden:"true" long:"perl" description:".pl .pm .pm6 .pod .t"`
+	PHP              bool `hidden:"true" long:"php" description:".php .phpt .php3 .php4 .php5 .phtml"`
+	Pike             bool `hidden:"true" long:"pike" description:".pike .pmod"`
+	Plone            bool `hidden:"true" long:"plone" description:".pt .cpt .metadata .cpy .py .xml .zcml"`
+	Proto            bool `hidden:"true" long:"proto" description:".proto"`
+	Puppet           bool `hidden:"true" long:"puppet" description:".pp"`
+	Python           bool `hidden:"true" long:"python" description:".py"`
+	QML              bool `hidden:"true" long:"qml" description:".qml"`
+	Racket           bool `hidden:"true" long:"racket" description:".rkt .ss .scm"`
+	Rake             bool `hidden:"true" long:"rake" description:".Rakefile"`
+	RestructuredText bool `hidden:"true" long:"restructuredtext" description:".rst"`
+	RS               bool `hidden:"true" long:"rs" description:".rs"`
+	R                bool `hidden:"true" long:"r" description:".R .Rmd .Rnw .Rtex .Rrst"`
+	Rdoc             bool `hidden:"true" long:"rdoc" description:".rdoc"`
+	Ruby             bool `hidden:"true" long:"ruby" description:".rb .rhtml .rjs .rxml .erb .rake .spec"`
+	Rust             bool `hidden:"true" long:"rust" description:".rs"`
+	Salt             bool `hidden:"true" long:"salt" description:".sls"`
+	Sass             bool `hidden:"true" long:"sass" description:".sass .scss"`
+	Scala            bool `hidden:"true" long:"scala" description:".scala"`
+	Scheme           bool `hidden:"true" long:"scheme" description:".scm .ss"`
+	Shell            bool `hidden:"true" long:"shell" description:".sh .bash .csh .tcsh .ksh .zsh .fish"`
+	Smalltalk        bool `hidden:"true" long:"smalltalk" description:".st"`
+	SML              bool `hidden:"true" long:"sml" description:".sml .fun .mlb .sig"`
+	SQL              bool `hidden:"true" long:"sql" description:".sql .ctl"`
+	Stylus           bool `hidden:"true" long:"stylus" description:".styl"`
+	Swift            bool `hidden:"true" long:"swift" description:".swift"`
+	TCL              bool `hidden:"true" long:"tcl" description:".tcl .itcl .itk"`
+	Tex              bool `hidden:"true" long:"tex" description:".tex .cls .sty"`
+	TT               bool `hidden:"true" long:"tt" description:".tt .tt2 .ttml"`
+	TOML             bool `hidden:"true" long:"toml" description:".toml"`
+	TS               bool `hidden:"true" long:"ts" description:".ts .tsx"`
+	Vala             bool `hidden:"true" long:"vala" description:".vala .vapi"`
+	VB               bool `hidden:"true" long:"vb" description:".bas .cls .frm .ctl .vb .resx"`
+	Velocity         bool `hidden:"true" long:"velocity" description:".vm .vtl .vsl"`
+	Verilog          bool `hidden:"true" long:"verilog" description:".v .vh .sv"`
+	VHDL             bool `hidden:"true" long:"vhdl" description:".vhd .vhdl"`
+	Vim              bool `hidden:"true" long:"vim" description:".vim"`
+	Wix              bool `hidden:"true" long:"wix" description:".wxi .wxs"`
+	WSDL             bool `hidden:"true" long:"wsdl" description:".wsdl"`
+	WADL             bool `hidden:"true" long:"wadl" description:".wadl"`
+	XML              bool `hidden:"true" long:"xml" description:".xml .dtd .xsl .xslt .ent .tld"`
+	YAML             bool `hidden:"true" long:"yaml" description:".yaml .yml"`
+}
+
+func newFileTypeOption() *FileTypeOption {
+	opt := &FileTypeOption{}
+	return opt
+}
+
 func newOptionParser(opts *Option) *flags.Parser {
 	output := flags.NewNamedParser("pt", flags.Default)
 	output.AddGroup("Output Options", "", &OutputOption{})
@@ -142,8 +255,12 @@ func newOptionParser(opts *Option) *flags.Parser {
 	search := flags.NewNamedParser("pt", flags.Default)
 	search.AddGroup("Search Options", "", &SearchOption{})
 
+	filetypes := flags.NewNamedParser("pt", flags.Default)
+	filetypes.AddGroup("File Type Options", "", &FileTypeOption{})
+
 	opts.OutputOption = newOutputOption()
 	opts.SearchOption = newSearchOption()
+	opts.FileTypeOption = newFileTypeOption()
 
 	parser := flags.NewParser(opts, flags.Default)
 	parser.Name = "pt"

--- a/platinum_searcher.go
+++ b/platinum_searcher.go
@@ -55,6 +55,11 @@ func (p PlatinumSearcher) Run(args []string) int {
 		return ExitCodeOK
 	}
 
+	if opts.FileTypeOption.ListFileTypes {
+		printFileTypeOptions()
+		return ExitCodeOK
+	}
+
 	if len(args) == 0 && !opts.SearchOption.EnableFilesWithRegexp {
 		parser.WriteHelp(p.Err)
 		return ExitCodeError

--- a/search.go
+++ b/search.go
@@ -45,6 +45,11 @@ func (s search) start(pattern string) error {
 		if err != nil {
 			return err
 		}
+	} else if pattern := fileTypeSearchPattern(); pattern != "" {
+		regFile, err = regexp.Compile(pattern)
+		if err != nil {
+			return err
+		}
 	}
 	if opts.SearchOption.EnableFilesWithRegexp {
 		opts.OutputOption.FilesWithMatches = true


### PR DESCRIPTION
This commit adds numerous file type options (as supported by ag).
Options are hidden from default help text.  Use --list-file-types to see
what's available.

Fixes #154