### PR TITLE
Improve find and grep performance

### DIFF
--- a/file_info.go
+++ b/file_info.go
@@ -7,30 +7,34 @@ import (
 )
 
 type fileInfo struct {
-	path string
-	os.FileInfo
+	path, name string
+	typ        os.FileMode
 }
 
-func (f fileInfo) isDir(follow bool) bool {
+func (f *fileInfo) isDir(follow bool) bool {
 	if follow && f.isSymlink() {
-		if _, err := ioutil.ReadDir(filepath.Join(f.path, f.FileInfo.Name())); err == nil {
+		if _, err := ioutil.ReadDir(filepath.Join(f.path, f.name)); err == nil {
 			return true
 		} else {
 			return false
 		}
 	} else {
-		return f.FileInfo.IsDir()
+		return f.typ&os.ModeDir == os.ModeDir
 	}
 }
 
-func (f fileInfo) isSymlink() bool {
-	return f.FileInfo.Mode()&os.ModeSymlink == os.ModeSymlink
+func (f *fileInfo) isSymlink() bool {
+	return f.typ&os.ModeSymlink == os.ModeSymlink
 }
 
-func (f fileInfo) isNamedPipe() bool {
-	return f.FileInfo.Mode()&os.ModeNamedPipe == os.ModeNamedPipe
+func (f *fileInfo) isNamedPipe() bool {
+	return f.typ&os.ModeNamedPipe == os.ModeNamedPipe
 }
 
-func newFileInfo(path string, info os.FileInfo) fileInfo {
-	return fileInfo{path, info}
+func newFileInfo(path, name string, typ os.FileMode) *fileInfo {
+	return &fileInfo{
+		path: path,
+		name: name,
+		typ:  typ,
+	}
 }

--- a/find.go
+++ b/find.go
@@ -64,13 +64,13 @@ func (f find) findFile(root string, regexp *regexp.Regexp) {
 	}
 
 	followed := f.opts.SearchOption.Follow
-	concurrentWalk(root, ignores, followed, func(path string, info fileInfo, depth int, ignores ignoreMatchers) (ignoreMatchers, error) {
+	concurrentWalk(root, ignores, followed, func(path string, info *fileInfo, depth int, ignores ignoreMatchers) (ignoreMatchers, error) {
 		if info.isDir(followed) {
 			if depth > f.opts.SearchOption.Depth+1 {
 				return ignores, filepath.SkipDir
 			}
 
-			if !f.opts.SearchOption.Hidden && isHidden(info.Name()) {
+			if !f.opts.SearchOption.Hidden && isHidden(info.name) {
 				return ignores, filepath.SkipDir
 			}
 
@@ -91,7 +91,7 @@ func (f find) findFile(root string, regexp *regexp.Regexp) {
 			return ignores, nil
 		}
 
-		if !f.opts.SearchOption.Hidden && isHidden(info.Name()) {
+		if !f.opts.SearchOption.Hidden && isHidden(info.name) {
 			return ignores, filepath.SkipDir
 		}
 

--- a/grep.go
+++ b/grep.go
@@ -8,6 +8,7 @@ type grep struct {
 	in      chan string
 	done    chan struct{}
 	grepper grepper
+	printer printer
 	opts    Option
 }
 
@@ -20,7 +21,8 @@ func newGrep(pattern pattern, in chan string, done chan struct{}, opts Option, p
 			printer,
 			opts,
 		),
-		opts: opts,
+		printer: printer,
+		opts:    opts,
 	}
 }
 
@@ -38,7 +40,8 @@ func (g grep) start() {
 		}(path)
 	}
 	wg.Wait()
-	g.done <- struct{}{}
+	close(g.printer.in)
+	g.done <- <-g.printer.done
 }
 
 type grepper interface {

--- a/line_grep_test.go
+++ b/line_grep_test.go
@@ -63,5 +63,8 @@ func assertLineGrep(opts Option, path string, expect string) bool {
 		return bytes.Contains(b, []byte("go"))
 	}, func(b []byte) int { return 0 })
 
+	close(printer.in)
+	<-printer.done
+
 	return buf.String() == expect
 }

--- a/platinum_searcher_test.go
+++ b/platinum_searcher_test.go
@@ -1,0 +1,24 @@
+package the_platinum_searcher
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func BenchmarkPT(b *testing.B) {
+	for name, args := range map[string][]string{
+		"findOnly": {"-g", ".", os.Getenv("GOPATH")},
+		"normal":   {"test", os.Getenv("GOPATH")},
+	} {
+		args := args
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				ret := PlatinumSearcher{Out: ioutil.Discard, Err: os.Stderr}.Run(args)
+				if ret != 0 {
+					b.Fatal("failed")
+				}
+			}
+		})
+	}
+}

--- a/readdir_dirent_fileno.go
+++ b/readdir_dirent_fileno.go
@@ -1,0 +1,9 @@
+// +build freebsd openbsd netbsd
+
+package the_platinum_searcher
+
+import "syscall"
+
+func direntInode(dirent *syscall.Dirent) uint64 {
+	return uint64(dirent.Fileno)
+}

--- a/readdir_dirent_ino.go
+++ b/readdir_dirent_ino.go
@@ -1,0 +1,9 @@
+// +build linux,!appengine darwin
+
+package the_platinum_searcher
+
+import "syscall"
+
+func direntInode(dirent *syscall.Dirent) uint64 {
+	return uint64(dirent.Ino)
+}

--- a/readdir_portable.go
+++ b/readdir_portable.go
@@ -1,0 +1,20 @@
+// +build appengine !linux,!darwin,!freebsd,!openbsd,!netbsd
+
+package the_platinum_searcher
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+func readDir(dirName string) ([]*fileInfo, error) {
+	fis := []*fileInfo{}
+	fs, err := ioutil.ReadDir(dirName)
+	if err != nil {
+		return nil, err
+	}
+	for _, fi := range fs {
+		fis = append(fis, newFileInfo(dirName, fi.Name(), fi.Mode()&os.ModeType))
+	}
+	return fis, nil
+}

--- a/readdir_unix.go
+++ b/readdir_unix.go
@@ -1,0 +1,117 @@
+// +build linux,!appengine darwin freebsd openbsd netbsd
+
+package the_platinum_searcher
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+const blockSize = 8 << 10
+
+// unknownFileMode is a sentinel (and bogus) os.FileMode
+// value used to represent a syscall.DT_UNKNOWN Dirent.Type.
+const unknownFileMode os.FileMode = os.ModeNamedPipe | os.ModeSocket | os.ModeDevice
+
+func readDir(dirName string) ([]*fileInfo, error) {
+	fd, err := syscall.Open(dirName, 0, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer syscall.Close(fd)
+
+	fis := []*fileInfo{}
+	// The buffer must be at least a block long.
+	buf := make([]byte, blockSize) // stack-allocated; doesn't escape
+	bufp := 0                      // starting read position in buf
+	nbuf := 0                      // end valid data in buf
+	for {
+		if bufp >= nbuf {
+			bufp = 0
+			nbuf, err = syscall.ReadDirent(fd, buf)
+			if err != nil {
+				return nil, os.NewSyscallError("readdirent", err)
+			}
+			if nbuf <= 0 {
+				return fis, nil
+			}
+		}
+		consumed, name, typ := parseDirEnt(buf[bufp:nbuf])
+		bufp += consumed
+		if name == "" || name == "." || name == ".." {
+			continue
+		}
+		// Fallback for filesystems (like old XFS) that don't
+		// support Dirent.Type and have DT_UNKNOWN (0) there
+		// instead.
+		if typ == unknownFileMode {
+			fi, err := os.Lstat(dirName + "/" + name)
+			if err != nil {
+				// It got deleted in the meantime.
+				if os.IsNotExist(err) {
+					continue
+				}
+				return nil, err
+			}
+			typ = fi.Mode() & os.ModeType
+		}
+		fis = append(fis, newFileInfo(dirName, name, typ))
+	}
+}
+
+func parseDirEnt(buf []byte) (consumed int, name string, typ os.FileMode) {
+	// golang.org/issue/15653
+	dirent := (*syscall.Dirent)(unsafe.Pointer(&buf[0]))
+	if v := unsafe.Offsetof(dirent.Reclen) + unsafe.Sizeof(dirent.Reclen); uintptr(len(buf)) < v {
+		panic(fmt.Sprintf("buf size of %d smaller than dirent header size %d", len(buf), v))
+	}
+	if len(buf) < int(dirent.Reclen) {
+		panic(fmt.Sprintf("buf size %d < record length %d", len(buf), dirent.Reclen))
+	}
+	consumed = int(dirent.Reclen)
+	if direntInode(dirent) == 0 { // File absent in directory.
+		return
+	}
+	switch dirent.Type {
+	case syscall.DT_REG:
+		typ = 0
+	case syscall.DT_DIR:
+		typ = os.ModeDir
+	case syscall.DT_LNK:
+		typ = os.ModeSymlink
+	case syscall.DT_BLK:
+		typ = os.ModeDevice
+	case syscall.DT_FIFO:
+		typ = os.ModeNamedPipe
+	case syscall.DT_SOCK:
+		typ = os.ModeSocket
+	case syscall.DT_UNKNOWN:
+		typ = unknownFileMode
+	default:
+		// Skip weird things.
+		// It's probably a DT_WHT (http://lwn.net/Articles/325369/)
+		// or something. Revisit if/when this package is moved outside
+		// of goimports. goimports only cares about regular files,
+		// symlinks, and directories.
+		return
+	}
+
+	nameBuf := (*[unsafe.Sizeof(dirent.Name)]byte)(unsafe.Pointer(&dirent.Name[0]))
+	nameLen := bytes.IndexByte(nameBuf[:], 0)
+	if nameLen < 0 {
+		panic("failed to find terminating 0 byte in dirent")
+	}
+
+	// Special cases for common things:
+	if nameLen == 1 && nameBuf[0] == '.' {
+		name = "."
+	} else if nameLen == 2 && nameBuf[0] == '.' && nameBuf[1] == '.' {
+		name = ".."
+	} else {
+		name = string(nameBuf[:nameLen])
+	}
+	return
+}


### PR DESCRIPTION
1. Use a faster `readdir` implement from [this](https://github.com/golang/tools/commit/edf8e6fef861d8c5ecc9e394b0146d6ebba57795).
2. Buffer output print.


Here is the benchmark result:

```
benchmark                  old ns/op     new ns/op     delta
BenchmarkPT/findOnly-4     171367748     31854579      -81.41%
BenchmarkPT/normal-4       302596661     280387391     -7.34%

benchmark                  old allocs     new allocs     delta
BenchmarkPT/findOnly-4     254596         172796         -32.13%
BenchmarkPT/normal-4       635247         552380         -13.04%

benchmark                  old bytes     new bytes     delta
BenchmarkPT/findOnly-4     45581341      9212957       -79.79%
BenchmarkPT/normal-4       366203739     329435411     -10.04%
```

Should fix issue #178 .