### PR TITLE
update readme: dirs that start with . are ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A code search tool similar to `ack` and `the_silver_searcher(ag)`. It supports m
 - It searches code about 3–5× faster than `ack`.
 - It searches code as fast as `the_silver_searcher(ag)`.
 - It ignores file patterns from your `.gitignore`.
+- It ignores directories with names that start with `.`, eg `.config`.
 - It searches `UTF-8`, `EUC-JP` and `Shift_JIS` files.
 - It provides binaries for multi platform (macOS, Windows, Linux).
 


### PR DESCRIPTION
I missed a match in a file `.circleci/config.yml`, when I moved the file it matched. This adds the observed behaviour to the readme.

Edit: observed in `pt version 2.1.5`