### PR TITLE
Print error rather than exit when encountering permission denied

### DIFF
--- a/decorator.go
+++ b/decorator.go
@@ -18,6 +18,7 @@ type decorator interface {
 	lineNumber(lineNum int) string
 	columnNumber(columnNum int) string
 	match(line string, matched bool) string
+	error(err error) string
 }
 
 func newDecorator(pattern pattern, option Option) decorator {
@@ -36,6 +37,7 @@ type color struct {
 	colorLineNumber string
 	colorPath       string
 	colorMatch      string
+	colorError      string
 }
 
 func newColor(pattern pattern, option Option) color {
@@ -43,6 +45,7 @@ func newColor(pattern pattern, option Option) color {
 		colorLineNumber: ansiEscape(option.OutputOption.ColorCodeLineNumber),
 		colorPath:       ansiEscape(option.OutputOption.ColorCodePath),
 		colorMatch:      ansiEscape(option.OutputOption.ColorCodeMatch),
+		colorError:      ansiEscape(option.OutputOption.ColorCodeError),
 	}
 	if pattern.regexp == nil {
 		p := string(pattern.pattern)
@@ -86,6 +89,10 @@ func (c color) match(line string, matched bool) string {
 	}
 }
 
+func (c color) error(err error) string {
+	return c.colorError + err.Error() + ColorReset + "\n"
+}
+
 type plain struct {
 }
 
@@ -103,4 +110,8 @@ func (p plain) columnNumber(columnNum int) string {
 
 func (p plain) match(line string, matched bool) string {
 	return line
+}
+
+func (c plain) error(err error) string {
+	return err.Error()
 }

--- a/extended_grep.go
+++ b/extended_grep.go
@@ -14,6 +14,10 @@ type extendedGrep struct {
 func (g extendedGrep) grep(path string) {
 	f, err := getFileHandler(path)
 	if err != nil {
+		if os.IsPermission(err) {
+			g.printer.printError(err)
+			return
+		}
 		log.Fatalf("open: %s\n", err)
 	}
 	defer f.Close()

--- a/fixed_grep.go
+++ b/fixed_grep.go
@@ -16,6 +16,10 @@ type fixedGrep struct {
 func (g fixedGrep) grep(path string) {
 	f, err := getFileHandler(path)
 	if err != nil {
+		if os.IsPermission(err) {
+			g.printer.printError(err)
+			return
+		}
 		log.Fatalf("open: %s\n", err)
 	}
 	defer f.Close()

--- a/formatter_test.go
+++ b/formatter_test.go
@@ -11,7 +11,7 @@ func ExampleFormatPrinterFileWithMatch() {
 	match.add(1, 0, "go test", true)
 
 	pattern, _ := newPattern("go", opts)
-	p := newFormatPrinter(pattern, os.Stdout, opts)
+	p := newFormatPrinter(pattern, os.Stdout, os.Stderr, opts)
 	p.print(match)
 
 	// Output:
@@ -27,7 +27,7 @@ func ExampleFormatPrinterCount() {
 	match.add(1, 0, "go test", true)
 
 	pattern, _ := newPattern("go", opts)
-	p := newFormatPrinter(pattern, os.Stdout, opts)
+	p := newFormatPrinter(pattern, os.Stdout, os.Stderr, opts)
 	p.print(match)
 
 	// Output:
@@ -45,7 +45,7 @@ func ExampleFormatEnableGroup() {
 	match.add(3, 0, "after", false)  // after
 
 	pattern, _ := newPattern("go", opts)
-	p := newFormatPrinter(pattern, os.Stdout, opts)
+	p := newFormatPrinter(pattern, os.Stdout, os.Stderr, opts)
 	p.print(match)
 
 	// Output:
@@ -66,7 +66,7 @@ func ExampleFormatEnableGroupWithColumn() {
 	match.add(3, 0, "after", false)  // after
 
 	pattern, _ := newPattern("go", opts)
-	p := newFormatPrinter(pattern, os.Stdout, opts)
+	p := newFormatPrinter(pattern, os.Stdout, os.Stderr, opts)
 	p.print(match)
 
 	// Output:
@@ -87,7 +87,7 @@ func ExampleFormatNoGroup() {
 	match.add(3, 0, "after", false)  // after
 
 	pattern, _ := newPattern("go", opts)
-	p := newFormatPrinter(pattern, os.Stdout, opts)
+	p := newFormatPrinter(pattern, os.Stdout, os.Stderr, opts)
 	p.print(match)
 
 	// Output:
@@ -107,7 +107,7 @@ func ExampleFormatNoGroupWithColumn() {
 	match.add(3, 0, "after", false)  // after
 
 	pattern, _ := newPattern("go", opts)
-	p := newFormatPrinter(pattern, os.Stdout, opts)
+	p := newFormatPrinter(pattern, os.Stdout, os.Stderr, opts)
 	p.print(match)
 
 	// Output:
@@ -127,7 +127,7 @@ func ExampleFormatMatchLine() {
 	match.add(3, 0, "after", false)  // after
 
 	pattern, _ := newPattern("go", opts)
-	p := newFormatPrinter(pattern, os.Stdout, opts)
+	p := newFormatPrinter(pattern, os.Stdout, os.Stderr, opts)
 	p.print(match)
 
 	// Output:
@@ -147,7 +147,7 @@ func ExampleFormatMatchLineWithColumn() {
 	match.add(3, 0, "after", false)  // after
 
 	pattern, _ := newPattern("go", opts)
-	p := newFormatPrinter(pattern, os.Stdout, opts)
+	p := newFormatPrinter(pattern, os.Stdout, os.Stderr, opts)
 	p.print(match)
 
 	// Output:

--- a/grep_test.go
+++ b/grep_test.go
@@ -119,7 +119,8 @@ func TestStdinGrep(t *testing.T) {
 
 func assertGrep(pattern pattern, opts Option, paths, asserts []string) bool {
 	buf := new(bytes.Buffer)
-	printer := newPrinter(pattern, buf, opts)
+	errBuf := new(bytes.Buffer)
+	printer := newPrinter(pattern, buf, errBuf, opts)
 
 	in := make(chan string)
 	done := make(chan struct{})

--- a/line_grep_test.go
+++ b/line_grep_test.go
@@ -54,7 +54,8 @@ files/context/context.txt:6:go test
 
 func assertLineGrep(opts Option, path string, expect string) bool {
 	buf := new(bytes.Buffer)
-	printer := newPrinter(pattern{}, buf, opts)
+	errBuf := new(bytes.Buffer)
+	printer := newPrinter(pattern{}, buf, errBuf, opts)
 	grep := newLineGrep(printer, opts)
 
 	f, _ := os.Open(path)

--- a/option.go
+++ b/option.go
@@ -18,9 +18,11 @@ type OutputOption struct {
 	ColorLineNumber     func(string) `long:"color-line-number" description:"Color codes for line numbers (default: 1;33)"`
 	ColorPath           func(string) `long:"color-path" description:"Color codes for path names (default: 1;32)"`
 	ColorMatch          func(string) `long:"color-match" description:"Color codes for result matches (default: 30;43)"`
+	ColorError          func(string) `long:"color-error" description:"Color codes for errors (default: 1;31)"`
 	ColorCodeLineNumber string       // Color line numbers. Not user option.
 	ColorCodePath       string       // Color path names. Not user option.
 	ColorCodeMatch      string       // Color result matches. Not user option.
+	ColorCodeError      string       // Color errors. Not user option.
 	Group               func()       `long:"group" description:"Print file name at header (default: true)"`
 	NoGroup             func()       `long:"nogroup" description:"Don't print file name at header (default: false)"`
 	ForceGroup          bool         // Force group. Not user option.
@@ -57,9 +59,11 @@ func newOutputOption() *OutputOption {
 	opt.ColorLineNumber = opt.SetColorLineNumber
 	opt.ColorPath = opt.SetColorPath
 	opt.ColorMatch = opt.SetColorMatch
+	opt.ColorError = opt.SetColorError
 	opt.ColorCodeLineNumber = "1;33" // yellow with black background
 	opt.ColorCodePath = "1;32"       // bold green
 	opt.ColorCodeMatch = "30;43"     // black with yellow background
+	opt.ColorCodeError = "1;31"      // bold red
 
 	return opt
 }
@@ -101,6 +105,10 @@ func (o *OutputOption) SetColorPath(code string) {
 
 func (o *OutputOption) SetColorMatch(code string) {
 	o.ColorCodeMatch = code
+}
+
+func (o *OutputOption) SetColorError(code string) {
+	o.ColorCodeError = code
 }
 
 // Search options.

--- a/platinum_searcher.go
+++ b/platinum_searcher.go
@@ -84,8 +84,9 @@ func (p PlatinumSearcher) Run(args []string) int {
 	}
 
 	search := search{
-		roots: p.rootsFrom(args),
-		out:   p.Out,
+		roots:       p.rootsFrom(args),
+		out:         p.Out,
+		errorWriter: p.Err,
 	}
 	if err = search.start(p.patternFrom(args)); err != nil {
 		fmt.Fprintf(p.Err, "%s\n", err)

--- a/print.go
+++ b/print.go
@@ -11,11 +11,16 @@ type printer struct {
 	formatter formatPrinter
 }
 
-func newPrinter(pattern pattern, out io.Writer, opts Option) printer {
+func newPrinter(
+	pattern pattern,
+	out,
+	errorWriter io.Writer,
+	opts Option,
+) printer {
 	return printer{
 		mu:        new(sync.Mutex),
 		opts:      opts,
-		formatter: newFormatPrinter(pattern, out, opts),
+		formatter: newFormatPrinter(pattern, out, errorWriter, opts),
 	}
 }
 
@@ -28,4 +33,11 @@ func (p printer) print(match match) {
 	}
 
 	p.formatter.print(match)
+}
+
+func (p printer) printError(err error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.formatter.printError(err)
 }

--- a/search.go
+++ b/search.go
@@ -6,8 +6,9 @@ import (
 )
 
 type search struct {
-	roots []string
-	out   io.Writer
+	roots       []string
+	out         io.Writer
+	errorWriter io.Writer
 }
 
 func (s search) start(pattern string) error {
@@ -66,7 +67,7 @@ func (s search) start(pattern string) error {
 		grepChan,
 		done,
 		opts,
-		newPrinter(p, s.out, opts),
+		newPrinter(p, s.out, s.errorWriter, opts),
 	).start()
 
 	<-done


### PR DESCRIPTION
Previously if we encountered a file we could not read for permission
reasons, we'd exit immediately. This meant that you either had to stop
and fix the permissions or tell pt to ignore the file.

Now we print the error out which is similar to what grep does.

Rather than using log.Printf which could have issues writing at the same
time as printing the matches, this uses the same printer. It also adds a
new colour code for errors so that they are more noticable when running
with coloured output.

This should resolve #145.