### PR TITLE
Fixes hang when not passing root folder on Windows

### DIFF
--- a/platinum_searcher.go
+++ b/platinum_searcher.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/monochromegane/conflag"
@@ -108,19 +107,13 @@ func (p PlatinumSearcher) rootsFrom(args []string) []string {
 
 func (p PlatinumSearcher) givenStdin() bool {
 	fi, err := os.Stdin.Stat()
-	if runtime.GOOS == "windows" {
-		if err == nil {
-			return true
-		}
-	} else {
-		if err != nil {
-			return false
-		}
+	if err != nil {
+		return false
+	}
 
-		mode := fi.Mode()
-		if (mode&os.ModeNamedPipe != 0) || mode.IsRegular() {
-			return true
-		}
+	mode := fi.Mode()
+	if (mode&os.ModeNamedPipe != 0) || mode.IsRegular() {
+		return true
 	}
 	return false
 }


### PR DESCRIPTION
This is a pull request to fix issue #199 
The special case for the Windows platform in function `givenStdin` should not be there.